### PR TITLE
[Website] Mediumのリンクを修正

### DIFF
--- a/apps/website/lib/ui/components/footer/site_footer.dart
+++ b/apps/website/lib/ui/components/footer/site_footer.dart
@@ -185,7 +185,7 @@ final class _SnsLinks extends StatelessWidget {
             width: 40,
             colorFilter: ColorFilter.mode(Colors.black, BlendMode.srcIn),
           ),
-          url: 'https://medium.com', // Replace with your URL
+          url: 'https://medium.com/flutterkaigi', // Replace with your URL
         ),
       ],
     );


### PR DESCRIPTION
## 概要
- リンク先が Mediumのホームページになっていたので、FlutterkaigiアカウントのMediumページへ変更