### PR TITLE
【App】ライセンスページを表示するようにしました。

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,1 @@
+{ "words": ["Kaigi"] }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,6 @@
   },
   "yaml.schemas": {
     "https://json.schemastore.org/github-issue-config.json": ".github/ISSUE_TEMPLATE/config.yaml"
-  }
+  },
+  "cSpell.words": ["Kaigi"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,5 @@
   },
   "yaml.schemas": {
     "https://json.schemastore.org/github-issue-config.json": ".github/ISSUE_TEMPLATE/config.yaml"
-  },
-  "cSpell.words": ["Kaigi"]
+  }
 }

--- a/apps/app/lib/main.dart
+++ b/apps/app/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:conference_2024_app/widget/debug_screen.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -11,9 +12,8 @@ class MainApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       home: Scaffold(
-        body: Center(
-          child: Text('Hello World!'),
-        ),
+        // TODO: ボトムナビゲーション#83が終わるまでデバッグ画面で動作確認する想定です。
+        body: DebugScreen(),
       ),
     );
   }

--- a/apps/app/lib/main.dart
+++ b/apps/app/lib/main.dart
@@ -12,7 +12,7 @@ class MainApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return const MaterialApp(
       home: Scaffold(
-        // TODO: ボトムナビゲーション#83が終わるまでデバッグ画面で動作確認する想定です。
+        // TODO: Figma のデザインで表示位置をFixし、さらにボトムナビゲーション#83 が完了するまでデバッグ画面で動作を確認する想定です。
         body: DebugScreen(),
       ),
     );

--- a/apps/app/lib/main.dart
+++ b/apps/app/lib/main.dart
@@ -13,6 +13,7 @@ class MainApp extends StatelessWidget {
     return const MaterialApp(
       home: Scaffold(
         // TODO: Figma のデザインで表示位置をFixし、さらにボトムナビゲーション#83 が完了するまでデバッグ画面で動作を確認する想定です。
+        // https://github.com/FlutterKaigi/2024/issues/118
         body: DebugScreen(),
       ),
     );

--- a/apps/app/lib/widget/debug_screen.dart
+++ b/apps/app/lib/widget/debug_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// 遷移処理の動作検証をするための画面
+class DebugScreen extends StatelessWidget {
+  const DebugScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.expand(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text('Hello World!'),
+          const SizedBox(
+            height: 24,
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(context, rootNavigator: true).push(
+                MaterialPageRoute<void>(
+                  builder: (context) => const LicensePage(
+                    applicationName: 'FlutterKaigi 2024 Official App',
+                  ),
+                ),
+              );
+            },
+            child: const Text('ライセンスページ'),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Issue

- https://github.com/FlutterKaigi/2024/issues/47
- https://github.com/FlutterKaigi/2024/issues/48

## 説明

ライセンスページをデバッグ画面で表示するようにしました

## 画像 / 動画

https://github.com/FlutterKaigi/2024/assets/162671982/1255df6f-51ad-4631-a422-eb09e728de7f


| Before | After | Design |
|-|-|-|
| | | |

## その他

<!--
デバッグ画面は一時的なものなので、TODOコメントとして記載してます。
デザインができた段階で正しい位置でライセンスページが遷移できる想定にしたいです。
-->
