### PR TITLE
[website] ローディングUI追加

### DIFF
--- a/apps/website/web/index.css
+++ b/apps/website/web/index.css
@@ -1,0 +1,22 @@
+:root {
+  --md-circular-progress-four-color-active-indicator-one-color: rgba(252, 0, 255, 0.35);
+  --md-circular-progress-four-color-active-indicator-two-color: rgba(125, 111, 238, 0.35);
+  --md-circular-progress-four-color-active-indicator-three-color: rgba(0, 219, 222, 0.35);
+  --md-circular-progress-four-color-active-indicator-four-color: rgba(125, 111, 238, 0.35);
+}
+
+body {
+  all: initial;
+  position: fixed;
+  overflow: hidden;
+  width: 100vw;
+  height: 100vh;
+}
+
+#loading {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+}

--- a/apps/website/web/index.html
+++ b/apps/website/web/index.html
@@ -4,6 +4,7 @@
     <base href="$FLUTTER_BASE_HREF" />
 
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
     <meta
       name="description"
@@ -49,8 +50,22 @@
       gtag("js", new Date());
       gtag("config", "G-Q0VWYGC7ZE");
     </script>
+
+    <!-- Load custom styles -->
+    <script type="importmap">
+      {
+        "imports": {
+          "@material/web/": "https://esm.run/@material/web@1.5.1/"
+        }
+      }
+    </script>
+    <script type="module" src="index.js"></script>
+    <link rel="stylesheet" href="index.css">
   </head>
   <body>
+    <div id="loading">
+      <md-circular-progress indeterminate four-color></md-circular-progress>
+    </div>
     <script src="flutter_bootstrap.js" async></script>
   </body>
 </html>

--- a/apps/website/web/index.js
+++ b/apps/website/web/index.js
@@ -1,0 +1,1 @@
+import "@material/web/progress/circular-progress.js";


### PR DESCRIPTION
## Issue

- Closes #121

## 説明

FlutterがロードされるまでのローディングUIを追加しました

## 画像 / 動画

https://github.com/FlutterKaigi/2024/assets/41745521/ee75ee18-4f35-46ec-a912-24fcf69a3589

## その他

[Material Web](https://github.com/material-components/material-web)を利用しています．
追加のビルドをしない方法で解決できたのでビルドフローは変更していません．

### 色に関して
FlutterKaigi 2024のカラーを指定しています．
Material WebのローディングUIに対してグラデーションを指定できそうになかったので4色の切り替える設定を適用しています．