### PR TITLE
feat: Flutter SDK バージョンを  3.23.0-13.0.pre に更新

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,5 +1,5 @@
 {
-  "flutter": "3.23.0-9.0.pre@master",
+  "flutter": "3.23.0-13.0.pre@master",
   "runPubGetOnSdkChanges": false,
   "updateVscodeSettings": false,
   "updateGitIgnore": false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "cwd": "apps/website",
       "request": "launch",
       "program": "lib/main.dart",
-      "args": ["--web-port", "8080"],
+      "args": ["--web-port", "8080", "--wasm"],
       "type": "dart"
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,15 @@
       "cwd": "apps/website",
       "request": "launch",
       "program": "lib/main.dart",
-      "args": ["--web-port", "8080", "--web-renderer", "canvaskit", "--wasm"],
+      "args": [
+        "--web-port",
+        "8080",
+        "--web-renderer",
+        // 何も指定してない場合 skwasm が指定されるが、なぜか開発環境だとリンクが期待通りに動作しない不具合が発生する
+        // そのため、現状 canvaskit を指定している
+        "canvaskit",
+        "--wasm"
+      ],
       "type": "dart"
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,14 @@
       "program": "lib/main.dart",
       "args": ["--web-port", "8080", "--web-renderer", "html"],
       "type": "dart"
+    },
+    {
+      "name": "website-canvaskit-wasm-debug",
+      "cwd": "apps/website",
+      "request": "launch",
+      "program": "lib/main.dart",
+      "args": ["--web-port", "8080", "--web-renderer", "canvaskit", "--wasm"],
+      "type": "dart"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,11 +9,11 @@
       "type": "dart"
     },
     {
-      "name": "website-debug",
+      "name": "website-html-debug",
       "cwd": "apps/website",
       "request": "launch",
       "program": "lib/main.dart",
-      "args": ["--web-port", "8080", "--wasm"],
+      "args": ["--web-port", "8080", "--web-renderer", "html"],
       "type": "dart"
     }
   ]

--- a/apps/app/l10n.yaml
+++ b/apps/app/l10n.yaml
@@ -7,6 +7,5 @@ synthetic-package: false
 preferred-supported-locales:
   - ja
   - en
-header: "// ignore_for_file: type=lint"
 nullable-getter: false
 format: true

--- a/apps/app/lib/gen/l10n/l10n.dart
+++ b/apps/app/lib/gen/l10n/l10n.dart
@@ -9,6 +9,8 @@ import 'package:intl/intl.dart' as intl;
 import 'l10n_en.dart';
 import 'l10n_ja.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of L10n
 /// returned by `L10n.of(context)`.
 ///

--- a/apps/app/lib/gen/l10n/l10n.dart
+++ b/apps/app/lib/gen/l10n/l10n.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type=lint
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/apps/app/lib/gen/l10n/l10n_en.dart
+++ b/apps/app/lib/gen/l10n/l10n_en.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/apps/app/lib/gen/l10n/l10n_en.dart
+++ b/apps/app/lib/gen/l10n/l10n_en.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class L10nEn extends L10n {
   L10nEn([String locale = 'en']) : super(locale);

--- a/apps/app/lib/gen/l10n/l10n_ja.dart
+++ b/apps/app/lib/gen/l10n/l10n_ja.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/apps/app/lib/gen/l10n/l10n_ja.dart
+++ b/apps/app/lib/gen/l10n/l10n_ja.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for Japanese (`ja`).
 class L10nJa extends L10n {
   L10nJa([String locale = 'ja']) : super(locale);

--- a/apps/app/pubspec.lock
+++ b/apps/app/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5aaf60d96c4cd00fe7f21594b5ad6a1b699c80a27420f8a837f4d68473ef09e3"
+      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
       url: "https://pub.dev"
     source: hosted
-    version: "68.0.0"
+    version: "72.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.1.5"
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "21f1d3720fd1c70316399d5e2bccaebb415c434592d778cce8acb967b8578808"
+      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.7.0"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -430,10 +430,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: a8403c89b36483b4cbf9f1fcd24562f483cb34a5c9bf101cf2b0d8a083cf1239
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0-main.5"
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
@@ -454,10 +454,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -694,10 +694,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   timing:
     dependency: transitive
     description:
@@ -734,10 +734,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.2"
+    version: "14.2.4"
   watcher:
     dependency: transitive
     description:
@@ -779,5 +779,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0-191.0.dev <4.0.0"
-  flutter: ">=3.23.0-9.0.pre"
+  dart: ">=3.5.0-293.0.dev <4.0.0"
+  flutter: ">=3.23.0-13.0.pre"

--- a/apps/app/pubspec.yaml
+++ b/apps/app/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 0.1.0
 
 environment:
-  sdk: ^3.5.0-191.0.dev
-  flutter: ^3.23.0-9.0.pre
+  sdk: ^3.5.0-293.0.dev
+  flutter: ^3.23.0-13.0.pre
 
 dependencies:
   flutter:

--- a/apps/website/pubspec.lock
+++ b/apps/website/pubspec.lock
@@ -457,10 +457,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -726,26 +726,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: d11b55850c68c1f6c0cf00eabded4e66c4043feaf6c0d7ce4a36785137df6331
+      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.5"
+    version: "1.25.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "4d070a6bc36c1c4e89f20d353bfd71dc30cdf2bd0e14349090af360a029ab292"
+      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.4"
   theme_tailor:
     dependency: "direct dev"
     description:
@@ -878,10 +878,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.2"
+    version: "14.2.4"
   watcher:
     dependency: transitive
     description:
@@ -939,5 +939,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0-191.0.dev <4.0.0"
-  flutter: ">=3.23.0-9.0.pre"
+  dart: ">=3.5.0-293.0.dev <4.0.0"
+  flutter: ">=3.23.0-13.0.pre"

--- a/apps/website/pubspec.yaml
+++ b/apps/website/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 0.1.0
 
 environment:
-  sdk: ^3.5.0-191.0.dev
-  flutter: ^3.23.0-9.0.pre
+  sdk: ^3.5.0-293.0.dev
+  flutter: ^3.23.0-13.0.pre
 
 dependencies:
   collection: ^1.18.0

--- a/melos.yaml
+++ b/melos.yaml
@@ -5,8 +5,8 @@ sdkPath: .fvm/flutter_sdk
 command:
   bootstrap:
     environment:
-      sdk: ^3.5.0-191.0.dev
-      flutter: ^3.23.0-9.0.pre
+      sdk: ^3.5.0-293.0.dev
+      flutter: ^3.23.0-13.0.pre
     dependencies:
       collection: ^1.18.0
       flutter:

--- a/packages/app/features/about/l10n.yaml
+++ b/packages/app/features/about/l10n.yaml
@@ -7,6 +7,5 @@ synthetic-package: false
 preferred-supported-locales:
   - ja
   - en
-header: "// ignore_for_file: type=lint"
 nullable-getter: false
 format: true

--- a/packages/app/features/about/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/about/lib/src/gen/l10n/l10n.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type=lint
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/packages/app/features/about/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/about/lib/src/gen/l10n/l10n.dart
@@ -9,6 +9,8 @@ import 'package:intl/intl.dart' as intl;
 import 'l10n_en.dart';
 import 'l10n_ja.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of L10nAbout
 /// returned by `L10nAbout.of(context)`.
 ///

--- a/packages/app/features/about/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/about/lib/src/gen/l10n/l10n_en.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/about/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/about/lib/src/gen/l10n/l10n_en.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class L10nAboutEn extends L10nAbout {
   L10nAboutEn([String locale = 'en']) : super(locale);

--- a/packages/app/features/about/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/about/lib/src/gen/l10n/l10n_ja.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/about/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/about/lib/src/gen/l10n/l10n_ja.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for Japanese (`ja`).
 class L10nAboutJa extends L10nAbout {
   L10nAboutJa([String locale = 'ja']) : super(locale);

--- a/packages/app/features/about/pubspec.lock
+++ b/packages/app/features/about/pubspec.lock
@@ -116,10 +116,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -177,10 +177,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -193,10 +193,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.2"
+    version: "14.2.4"
 sdks:
-  dart: ">=3.5.0-191.0.dev <4.0.0"
-  flutter: ">=3.23.0-9.0.pre"
+  dart: ">=3.5.0-293.0.dev <4.0.0"
+  flutter: ">=3.23.0-13.0.pre"

--- a/packages/app/features/about/pubspec.yaml
+++ b/packages/app/features/about/pubspec.yaml
@@ -5,8 +5,8 @@ version: 0.0.1
 homepage: "https://github.com/FlutterKaigi/2024/tree/main/packages/app/features/about"
 
 environment:
-  sdk: ^3.5.0-191.0.dev
-  flutter: ^3.23.0-9.0.pre
+  sdk: ^3.5.0-293.0.dev
+  flutter: ^3.23.0-13.0.pre
 
 dependencies:
   flutter:

--- a/packages/app/features/debug/l10n.yaml
+++ b/packages/app/features/debug/l10n.yaml
@@ -7,6 +7,5 @@ synthetic-package: false
 preferred-supported-locales:
   - ja
   - en
-header: "// ignore_for_file: type=lint"
 nullable-getter: false
 format: true

--- a/packages/app/features/debug/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/debug/lib/src/gen/l10n/l10n.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type=lint
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/packages/app/features/debug/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/debug/lib/src/gen/l10n/l10n.dart
@@ -9,6 +9,8 @@ import 'package:intl/intl.dart' as intl;
 import 'l10n_en.dart';
 import 'l10n_ja.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of L10nDebug
 /// returned by `L10nDebug.of(context)`.
 ///

--- a/packages/app/features/debug/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/debug/lib/src/gen/l10n/l10n_en.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/debug/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/debug/lib/src/gen/l10n/l10n_en.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class L10nDebugEn extends L10nDebug {
   L10nDebugEn([String locale = 'en']) : super(locale);

--- a/packages/app/features/debug/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/debug/lib/src/gen/l10n/l10n_ja.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/debug/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/debug/lib/src/gen/l10n/l10n_ja.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for Japanese (`ja`).
 class L10nDebugJa extends L10nDebug {
   L10nDebugJa([String locale = 'ja']) : super(locale);

--- a/packages/app/features/debug/pubspec.lock
+++ b/packages/app/features/debug/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5aaf60d96c4cd00fe7f21594b5ad6a1b699c80a27420f8a837f4d68473ef09e3"
+      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
       url: "https://pub.dev"
     source: hosted
-    version: "68.0.0"
+    version: "72.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.1.5"
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "21f1d3720fd1c70316399d5e2bccaebb415c434592d778cce8acb967b8578808"
+      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.7.0"
   args:
     dependency: transitive
     description:
@@ -350,10 +350,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: a8403c89b36483b4cbf9f1fcd24562f483cb34a5c9bf101cf2b0d8a083cf1239
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0-main.5"
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
@@ -374,10 +374,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -515,10 +515,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   timing:
     dependency: transitive
     description:
@@ -547,10 +547,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.2"
+    version: "14.2.4"
   watcher:
     dependency: transitive
     description:
@@ -592,5 +592,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0-191.0.dev <4.0.0"
-  flutter: ">=3.23.0-9.0.pre"
+  dart: ">=3.5.0-293.0.dev <4.0.0"
+  flutter: ">=3.23.0-13.0.pre"

--- a/packages/app/features/debug/pubspec.yaml
+++ b/packages/app/features/debug/pubspec.yaml
@@ -5,8 +5,8 @@ version: 0.0.1
 homepage: "https://github.com/FlutterKaigi/2024/tree/main/packages/app/features/debug"
 
 environment:
-  sdk: ^3.5.0-191.0.dev
-  flutter: ^3.23.0-9.0.pre
+  sdk: ^3.5.0-293.0.dev
+  flutter: ^3.23.0-13.0.pre
 
 dependencies:
   flutter:

--- a/packages/app/features/news/l10n.yaml
+++ b/packages/app/features/news/l10n.yaml
@@ -7,6 +7,5 @@ synthetic-package: false
 preferred-supported-locales:
   - ja
   - en
-header: "// ignore_for_file: type=lint"
 nullable-getter: false
 format: true

--- a/packages/app/features/news/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/news/lib/src/gen/l10n/l10n.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type=lint
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/packages/app/features/news/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/news/lib/src/gen/l10n/l10n.dart
@@ -9,6 +9,8 @@ import 'package:intl/intl.dart' as intl;
 import 'l10n_en.dart';
 import 'l10n_ja.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of L10nNews
 /// returned by `L10nNews.of(context)`.
 ///

--- a/packages/app/features/news/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/news/lib/src/gen/l10n/l10n_en.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/news/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/news/lib/src/gen/l10n/l10n_en.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class L10nNewsEn extends L10nNews {
   L10nNewsEn([String locale = 'en']) : super(locale);

--- a/packages/app/features/news/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/news/lib/src/gen/l10n/l10n_ja.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/news/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/news/lib/src/gen/l10n/l10n_ja.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for Japanese (`ja`).
 class L10nNewsJa extends L10nNews {
   L10nNewsJa([String locale = 'ja']) : super(locale);

--- a/packages/app/features/news/pubspec.lock
+++ b/packages/app/features/news/pubspec.lock
@@ -116,10 +116,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -177,10 +177,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -193,10 +193,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.2"
+    version: "14.2.4"
 sdks:
-  dart: ">=3.5.0-191.0.dev <4.0.0"
-  flutter: ">=3.23.0-9.0.pre"
+  dart: ">=3.5.0-293.0.dev <4.0.0"
+  flutter: ">=3.23.0-13.0.pre"

--- a/packages/app/features/news/pubspec.yaml
+++ b/packages/app/features/news/pubspec.yaml
@@ -5,8 +5,8 @@ version: 0.0.1
 homepage: "https://github.com/FlutterKaigi/2024/tree/main/packages/app/features/news"
 
 environment:
-  sdk: ^3.5.0-191.0.dev
-  flutter: ^3.23.0-9.0.pre
+  sdk: ^3.5.0-293.0.dev
+  flutter: ^3.23.0-13.0.pre
 
 dependencies:
   flutter:

--- a/packages/app/features/session/l10n.yaml
+++ b/packages/app/features/session/l10n.yaml
@@ -7,6 +7,5 @@ synthetic-package: false
 preferred-supported-locales:
   - ja
   - en
-header: "// ignore_for_file: type=lint"
 nullable-getter: false
 format: true

--- a/packages/app/features/session/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type=lint
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/packages/app/features/session/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n.dart
@@ -9,6 +9,8 @@ import 'package:intl/intl.dart' as intl;
 import 'l10n_en.dart';
 import 'l10n_ja.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of L10nSession
 /// returned by `L10nSession.of(context)`.
 ///

--- a/packages/app/features/session/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n_en.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/session/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n_en.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class L10nSessionEn extends L10nSession {
   L10nSessionEn([String locale = 'en']) : super(locale);

--- a/packages/app/features/session/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n_ja.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/session/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n_ja.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for Japanese (`ja`).
 class L10nSessionJa extends L10nSession {
   L10nSessionJa([String locale = 'ja']) : super(locale);

--- a/packages/app/features/session/pubspec.lock
+++ b/packages/app/features/session/pubspec.lock
@@ -116,10 +116,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -177,10 +177,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -193,10 +193,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.2"
+    version: "14.2.4"
 sdks:
-  dart: ">=3.5.0-191.0.dev <4.0.0"
-  flutter: ">=3.23.0-9.0.pre"
+  dart: ">=3.5.0-293.0.dev <4.0.0"
+  flutter: ">=3.23.0-13.0.pre"

--- a/packages/app/features/session/pubspec.yaml
+++ b/packages/app/features/session/pubspec.yaml
@@ -5,8 +5,8 @@ version: 0.0.1
 homepage: "https://github.com/FlutterKaigi/2024/tree/main/packages/app/features/session"
 
 environment:
-  sdk: ^3.5.0-191.0.dev
-  flutter: ^3.23.0-9.0.pre
+  sdk: ^3.5.0-293.0.dev
+  flutter: ^3.23.0-13.0.pre
 
 dependencies:
   flutter:

--- a/packages/app/features/venue/l10n.yaml
+++ b/packages/app/features/venue/l10n.yaml
@@ -7,6 +7,5 @@ synthetic-package: false
 preferred-supported-locales:
   - ja
   - en
-header: "// ignore_for_file: type=lint"
 nullable-getter: false
 format: true

--- a/packages/app/features/venue/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/venue/lib/src/gen/l10n/l10n.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: type=lint
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/packages/app/features/venue/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/venue/lib/src/gen/l10n/l10n.dart
@@ -9,6 +9,8 @@ import 'package:intl/intl.dart' as intl;
 import 'l10n_en.dart';
 import 'l10n_ja.dart';
 
+// ignore_for_file: type=lint
+
 /// Callers can lookup localized strings with an instance of L10nVenue
 /// returned by `L10nVenue.of(context)`.
 ///

--- a/packages/app/features/venue/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/venue/lib/src/gen/l10n/l10n_en.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/venue/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/venue/lib/src/gen/l10n/l10n_en.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for English (`en`).
 class L10nVenueEn extends L10nVenue {
   L10nVenueEn([String locale = 'en']) : super(locale);

--- a/packages/app/features/venue/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/venue/lib/src/gen/l10n/l10n_ja.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: type=lint
-
 import 'l10n.dart';
 
 // ignore_for_file: type=lint

--- a/packages/app/features/venue/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/venue/lib/src/gen/l10n/l10n_ja.dart
@@ -2,6 +2,8 @@
 
 import 'l10n.dart';
 
+// ignore_for_file: type=lint
+
 /// The translations for Japanese (`ja`).
 class L10nVenueJa extends L10nVenue {
   L10nVenueJa([String locale = 'ja']) : super(locale);

--- a/packages/app/features/venue/pubspec.lock
+++ b/packages/app/features/venue/pubspec.lock
@@ -116,10 +116,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "25dfcaf170a0190f47ca6355bdd4552cb8924b430512ff0cafb8db9bd41fe33b"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -177,10 +177,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2419f20b0c8677b2d67c8ac4d1ac7372d862dc6c460cdbb052b40155408cd794"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -193,10 +193,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "7475cb4dd713d57b6f7464c0e13f06da0d535d8b2067e188962a59bac2cf280b"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.2"
+    version: "14.2.4"
 sdks:
-  dart: ">=3.5.0-191.0.dev <4.0.0"
-  flutter: ">=3.23.0-9.0.pre"
+  dart: ">=3.5.0-293.0.dev <4.0.0"
+  flutter: ">=3.23.0-13.0.pre"

--- a/packages/app/features/venue/pubspec.yaml
+++ b/packages/app/features/venue/pubspec.yaml
@@ -5,8 +5,8 @@ version: 0.0.1
 homepage: "https://github.com/FlutterKaigi/2024/tree/main/packages/app/features/venue"
 
 environment:
-  sdk: ^3.5.0-191.0.dev
-  flutter: ^3.23.0-9.0.pre
+  sdk: ^3.5.0-293.0.dev
+  flutter: ^3.23.0-13.0.pre
 
 dependencies:
   flutter:

--- a/packages/common/data/pubspec.lock
+++ b/packages/common/data/pubspec.lock
@@ -5,23 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5aaf60d96c4cd00fe7f21594b5ad6a1b699c80a27420f8a837f4d68473ef09e3"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "68.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.1.5"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "21f1d3720fd1c70316399d5e2bccaebb415c434592d778cce8acb967b8578808"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.4.1"
   args:
     dependency: transitive
     description:
@@ -142,14 +137,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: a8403c89b36483b4cbf9f1fcd24562f483cb34a5c9bf101cf2b0d8a083cf1239
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0-main.5"
   matcher:
     dependency: transitive
     description:
@@ -383,4 +370,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0-191.0.dev <4.0.0"
+  dart: ">=3.5.0-293.0.dev <4.0.0"

--- a/packages/common/data/pubspec.yaml
+++ b/packages/common/data/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/FlutterKaigi/2024/tree/main/packages/common/data
 issue_tracker: https://github.com/FlutterKaigi/2024/issues
 
 environment:
-  sdk: ^3.5.0-191.0.dev
+  sdk: ^3.5.0-293.0.dev
 
 dev_dependencies:
   test: ^1.24.0


### PR DESCRIPTION
## Issue

- Closes #130 

## 説明

Flutter SDK バージョンを 3.23.0-13.0.pre に更新しました。

↓ の変更によって、デフォルトで選択される `--web-render` が `html` から `canvaskit` に変更されました。
https://github.com/flutter/flutter/pull/149773

下記の場合だと、ローカル環境ではうまく動作しないことが判明したため
- `--web-renderer=canvaskit`
  - `TypeError: Cannot read properties of undefined (reading 'MaterialApp')` などのエラーが発生する
- `--web-renderer=skwasm` + `--wasm`
  - 一部のリンクが機能しなくなる（ローカル環境だと Flutter のバージョンを上げる前からこの挙動になる）

いったん、次のようにローカル環境の起動設定を変更しました。
- `--web-renderer=html`
  - 元々指定していない場合はこちらの挙動になっていた
  - ブレイクポイントが機能するなど、デバッグがしやすい
- `--web-renderer=canvaskit` + `--wasm`
  - ローカル環境でも wasm を有効にしてある程度動作確認できるようにするため追加した

デプロイ時には `--web-renderer=skwasm` + `--wasm` でビルドしていますが、現状問題発生していないようなので、いったん特に修正せずに様子見します。

## 画像 / 動画

### ウェブサイト

※ ４倍速

https://github.com/FlutterKaigi/2024/assets/32213113/47fb697c-86bd-43c5-8b6a-4ac41821c4cf

### アプリ

https://github.com/FlutterKaigi/2024/assets/32213113/e81445f0-dcd6-4a06-8f4e-2725eb4e21af

## その他

- Android・iOS に関する更新差分がないことは確認済みです。
  - https://github.com/blendthink/flutter-mobile-template-diff/pull/15/files
- 差分です。
  - https://github.com/flutter/flutter/compare/3.23.0-9.0.pre...3.23.0-13.0.pre