### PR TITLE
chore: tasks.json を作成して supabase 関連のよく使うコマンドを設定

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,61 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "supabase-start",
+      "type": "shell",
+      "command": "supabase",
+      "args": ["start", "--workdir", "${workspaceFolder}/packages/common/data"]
+    },
+    {
+      "label": "supabase-stop",
+      "type": "shell",
+      "command": "supabase",
+      "args": ["stop", "--workdir", "${workspaceFolder}/packages/common/data"]
+    },
+    {
+      "label": "supabase-migration-new",
+      "type": "shell",
+      "command": "supabase",
+      "args": [
+        "migration",
+        "new",
+        "${input:migrationName}",
+        "--workdir",
+        "${workspaceFolder}/packages/common/data"
+      ]
+    },
+    {
+      "label": "supabase-migration-up",
+      "type": "shell",
+      "command": "supabase",
+      "args": [
+        "migration",
+        "up",
+        "--local",
+        "--workdir",
+        "${workspaceFolder}/packages/common/data"
+      ]
+    },
+    {
+      "label": "supabase-db-reset",
+      "type": "shell",
+      "command": "supabase",
+      "args": [
+        "db",
+        "reset",
+        "--workdir",
+        "${workspaceFolder}/packages/common/data"
+      ]
+    }
+  ],
+  "inputs": [
+    {
+      "id": "migrationName",
+      "type": "promptString",
+      "description": "Migration name"
+    }
+  ]
+}


### PR DESCRIPTION
## Issue

なし

## 説明

tasks.json を作成して supabase 関連のよく使うコマンドを設定しました。

## 画像 / 動画

VS Code 上でコマンドを実行している様子です。

### supabase start を実行

https://github.com/user-attachments/assets/f506f536-63f8-4e25-91c9-da84e5399aa6

### supabase migration new を実行

https://github.com/user-attachments/assets/fde25577-5efe-4c6b-accb-9f62a60436e3

## その他

- https://code.visualstudio.com/docs/editor/tasks
- https://supabase.com/docs/reference/cli