### PR TITLE
[Website] slang.yamlからbuild.yamlに設定ファイルを変更

### DIFF
--- a/apps/website/build.yaml
+++ b/apps/website/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      slang_build_runner:
+        options:
+          base_locale: ja

--- a/apps/website/slang.yaml
+++ b/apps/website/slang.yaml
@@ -1,1 +1,0 @@
-base_locale: ja


### PR DESCRIPTION
## 概要
- slangの設定を記述するファイルを変更しました 
  - `slang.yaml`から`build.yaml`に設定記述場所を変更しました

