### PR TITLE
[App] プライバシーポリシー(外部サイト)へ遷移する

### DIFF
--- a/packages/app/features/about/assets/l10n/app_en.arb
+++ b/packages/app/features/about/assets/l10n/app_en.arb
@@ -11,6 +11,7 @@
   "codeOfConduct": "Code of conduct",
   "codeOfConductUrl": "https://flutterkaigi.jp/flutterkaigi/Code-of-Conduct.html",
   "privacyPolicy": "Privacy policy",
+  "privacyPolicyUrl": "https://flutterkaigi.jp/flutterkaigi/Privacy-Policy.html",
   "contactUs": "Contact us",
   "ossLicenses": "OSS Licenses",
   "licensesAboutUs": "Flutter and the related logo are trademarks of Google LLC. FlutterKaigi is not affiliated with or otherwise sponsored by Google LLC.",

--- a/packages/app/features/about/assets/l10n/app_ja.arb
+++ b/packages/app/features/about/assets/l10n/app_ja.arb
@@ -11,6 +11,7 @@
   "codeOfConduct": "行動規範",
   "codeOfConductUrl": "https://flutterkaigi.jp/flutterkaigi/Code-of-Conduct.ja.html",
   "privacyPolicy": "プライバシーポリシー",
+  "privacyPolicyUrl": "https://flutterkaigi.jp/flutterkaigi/Privacy-Policy.ja.html",
   "contactUs": "お問い合わせ",
   "ossLicenses": "OSS Licenses",
   "licensesAboutUs": "Flutterおよび関連ロゴはGoogle LLCの商標です。FlutterKaigiはGoogle LLCとは提携しておらず、または他の形でスポンサーを受けていません。",

--- a/packages/app/features/about/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/about/lib/src/gen/l10n/l10n.dart
@@ -169,6 +169,12 @@ abstract class L10nAbout {
   /// **'プライバシーポリシー'**
   String get privacyPolicy;
 
+  /// No description provided for @privacyPolicyUrl.
+  ///
+  /// In ja, this message translates to:
+  /// **'https://flutterkaigi.jp/flutterkaigi/Privacy-Policy.ja.html'**
+  String get privacyPolicyUrl;
+
   /// No description provided for @contactUs.
   ///
   /// In ja, this message translates to:

--- a/packages/app/features/about/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/about/lib/src/gen/l10n/l10n_en.dart
@@ -45,6 +45,10 @@ class L10nAboutEn extends L10nAbout {
   String get privacyPolicy => 'Privacy policy';
 
   @override
+  String get privacyPolicyUrl =>
+      'https://flutterkaigi.jp/flutterkaigi/Privacy-Policy.html';
+
+  @override
   String get contactUs => 'Contact us';
 
   @override

--- a/packages/app/features/about/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/about/lib/src/gen/l10n/l10n_ja.dart
@@ -45,6 +45,10 @@ class L10nAboutJa extends L10nAbout {
   String get privacyPolicy => 'プライバシーポリシー';
 
   @override
+  String get privacyPolicyUrl =>
+      'https://flutterkaigi.jp/flutterkaigi/Privacy-Policy.ja.html';
+
+  @override
   String get contactUs => 'お問い合わせ';
 
   @override

--- a/packages/app/features/about/lib/src/ui/about_page.dart
+++ b/packages/app/features/about/lib/src/ui/about_page.dart
@@ -133,7 +133,10 @@ class AboutPage extends StatelessWidget {
               ListTile(
                 title: Text(l.privacyPolicy),
                 trailing: const Icon(Icons.arrow_forward_ios_outlined),
-                onTap: () {},
+                onTap: () async {
+                  final url = Uri.parse(l.privacyPolicyUrl);
+                  await launchInExternalApp(url);
+                },
               ),
               ListTile(
                 title: Text(l.contactUs),


### PR DESCRIPTION
## Issue

- Closes #44 

## 説明

<!--
必ず書いてください。
やったことをわかりやすく短く書いてください。
-->

- プライバシーポリシー ページ（外部サイト）への遷移する機能を作成しました。

## 画像 / 動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| 日本語 | 英語 | Design |
|-|-|-|
| <video src="https://github.com/user-attachments/assets/77ac2977-4d58-483e-a2e4-abb117e67d3b" width="300" />  | <video src="https://github.com/user-attachments/assets/45a15214-4113-4dfb-8a3f-7e5cee5b0827" width="300" /> | <img src="https://github.com/user-attachments/assets/b4ad5ad8-f89d-452a-a4e6-438e7cd862d4" width="300" /> |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->

- 特になし