### PR TITLE
fix: analysis_options.yamlをapps/*にも追加

### DIFF
--- a/apps/app/analysis_options.yaml
+++ b/apps/app/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: ../../analysis_options.yaml
+
+analyzer:
+  plugins:
+    - custom_lint
+  errors:
+    invalid_annotation_target: ignore

--- a/apps/website/analysis_options.yaml
+++ b/apps/website/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: ../../analysis_options.yaml
+
+analyzer:
+  plugins:
+    - custom_lint
+  errors:
+    invalid_annotation_target: ignore


### PR DESCRIPTION
## 概要
- apps/* の`analysis_options.yaml`が配置されておらず、Linterが無効だったため セットしました。