### PR TITLE
feat: Add sync shared_preferences provider

### DIFF
--- a/apps/app/lib/main.dart
+++ b/apps/app/lib/main.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 
 import 'package:accessibility_tools/accessibility_tools.dart';
+import 'package:app_cores_core/providers.dart';
 import 'package:app_cores_designsystem/theme.dart';
 import 'package:app_cores_settings/l10n.dart';
 import 'package:common_data/supabase_initializer.dart';
@@ -26,6 +27,8 @@ void main() async {
     anonKey: const String.fromEnvironment('SUPABASE_ANON_KEY'),
   );
   await supabaseInitializer.initialize();
+
+  await initSharedPreferencesInstance();
 
   runApp(
     const ProviderScope(

--- a/packages/app/cores/core/lib/src/providers/shared_preferences_instance.dart
+++ b/packages/app/cores/core/lib/src/providers/shared_preferences_instance.dart
@@ -3,9 +3,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 part 'shared_preferences_instance.g.dart';
 
-@riverpod
-Future<SharedPreferences> sharedPreferencesInstance(
-  SharedPreferencesInstanceRef ref,
-) async {
-  return SharedPreferences.getInstance();
+late SharedPreferences _sharedPreferences;
+
+/// [SharedPreferences] instance initialization.
+Future<void> initSharedPreferencesInstance() async {
+  _sharedPreferences = await SharedPreferences.getInstance();
 }
+
+/// This provider requires calling [initSharedPreferencesInstance] in advance.
+@riverpod
+SharedPreferences sharedPreferencesInstance(
+  SharedPreferencesInstanceRef ref,
+) =>
+    _sharedPreferences;

--- a/packages/app/cores/core/lib/src/providers/shared_preferences_instance.dart
+++ b/packages/app/cores/core/lib/src/providers/shared_preferences_instance.dart
@@ -6,8 +6,10 @@ part 'shared_preferences_instance.g.dart';
 late SharedPreferences _sharedPreferences;
 
 /// [SharedPreferences] instance initialization.
-Future<void> initSharedPreferencesInstance() async {
-  _sharedPreferences = await SharedPreferences.getInstance();
+Future<void> initSharedPreferencesInstance({
+  SharedPreferences? preferences,
+}) async {
+  _sharedPreferences = preferences ?? await SharedPreferences.getInstance();
 }
 
 /// This provider requires calling [initSharedPreferencesInstance] in advance.

--- a/packages/app/cores/core/lib/src/providers/shared_preferences_instance.g.dart
+++ b/packages/app/cores/core/lib/src/providers/shared_preferences_instance.g.dart
@@ -7,12 +7,14 @@ part of 'shared_preferences_instance.dart';
 // **************************************************************************
 
 String _$sharedPreferencesInstanceHash() =>
-    r'6b647159a531e64198d5d8f04afd60e2a9978a96';
+    r'94b3ee34ea4111b4be3fecda1c00fa24da731565';
 
-/// See also [sharedPreferencesInstance].
+/// This provider requires calling [initSharedPreferencesInstance] in advance.
+///
+/// Copied from [sharedPreferencesInstance].
 @ProviderFor(sharedPreferencesInstance)
 final sharedPreferencesInstanceProvider =
-    AutoDisposeFutureProvider<SharedPreferences>.internal(
+    AutoDisposeProvider<SharedPreferences>.internal(
   sharedPreferencesInstance,
   name: r'sharedPreferencesInstanceProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
@@ -23,6 +25,6 @@ final sharedPreferencesInstanceProvider =
 );
 
 typedef SharedPreferencesInstanceRef
-    = AutoDisposeFutureProviderRef<SharedPreferences>;
+    = AutoDisposeProviderRef<SharedPreferences>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/packages/app/cores/designsystem/lib/src/font_family.dart
+++ b/packages/app/cores/designsystem/lib/src/font_family.dart
@@ -33,9 +33,8 @@ enum FontFamily {
 class FontFamilyStore extends _$FontFamilyStore {
   @override
   FontFamily build() {
-    final sharedPreference =
-        ref.watch(sharedPreferencesInstanceProvider).valueOrNull;
-    final stored = sharedPreference?.getString(_persistKey);
+    final sharedPreference = ref.watch(sharedPreferencesInstanceProvider);
+    final stored = sharedPreference.getString(_persistKey);
 
     if (stored == null) {
       return FontFamily.system;
@@ -46,10 +45,9 @@ class FontFamilyStore extends _$FontFamilyStore {
 
   void update(FontFamily fontFamily) {
     state = fontFamily;
-    final sharedPreference =
-        ref.read(sharedPreferencesInstanceProvider).valueOrNull;
+    final sharedPreference = ref.read(sharedPreferencesInstanceProvider);
     unawaited(
-      sharedPreference?.setString(_persistKey, fontFamily.name),
+      sharedPreference.setString(_persistKey, fontFamily.name),
     );
   }
 }

--- a/packages/app/cores/designsystem/lib/src/font_family.g.dart
+++ b/packages/app/cores/designsystem/lib/src/font_family.g.dart
@@ -6,7 +6,7 @@ part of 'font_family.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$fontFamilyStoreHash() => r'd04683cee6dfd1f61cdcd0adbf243b7639db841b';
+String _$fontFamilyStoreHash() => r'e32c86523f8a189d2eab6b8acf9736fb416b22c6';
 
 /// See also [FontFamilyStore].
 @ProviderFor(FontFamilyStore)

--- a/packages/app/cores/designsystem/lib/src/font_family.g.dart
+++ b/packages/app/cores/designsystem/lib/src/font_family.g.dart
@@ -6,7 +6,7 @@ part of 'font_family.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$fontFamilyStoreHash() => r'e32c86523f8a189d2eab6b8acf9736fb416b22c6';
+String _$fontFamilyStoreHash() => r'7ca0d12c5a4acb73f57a3a24812d73fdb0d02b44';
 
 /// See also [FontFamilyStore].
 @ProviderFor(FontFamilyStore)


### PR DESCRIPTION
## Issue

- Closes none

## 説明

https://github.com/FlutterKaigi/2024/pull/199#discussion_r1739606450

上記コメントを見ました。SharedPreferencesに同期的にアクセスできるのは(結構)便利なため、Providerの実装を整理し、同期的にアクセスできるようにしています。
`late`によるunwrapとなるため、main functionにてinitを実行しないとruntime exceptionとなります。ただ、これぐらいなら許容できるのではないか、と考えています。

<!--
必ず書いてください。
やったことをわかりやすく短く書いてください。
-->

## 画像 / 動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
|-|-|-|
| | | |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
