### PR TITLE
[data, ticket] stripe data connectのセットアップ

### DIFF
--- a/packages/common/data/supabase/migrations/20240904185013_add_stripe_wrapper.sql
+++ b/packages/common/data/supabase/migrations/20240904185013_add_stripe_wrapper.sql
@@ -1,0 +1,27 @@
+-- https://supabase.com/docs/guides/database/extensions/wrappers/stripe
+CREATE EXTENSION if NOT EXISTS wrappers
+WITH
+  schema extensions;
+
+CREATE FOREIGN DATA WRAPPER stripe_wrapper handler stripe_fdw_handler validator stripe_fdw_validator;
+
+/*
+-- Save your Stripe API key in Vault and retrieve the `key_id`
+insert into vault.secrets (name, secret)
+values (
+'stripe',
+'YOUR_SECRET'
+)
+returning key_id;
+*/
+CREATE SERVER stripe_server FOREIGN data wrapper stripe_wrapper options (
+  api_key_id '89fec8a6-bc72-4b89-a8f6-09f4539d7ce5', -- The Key ID from above, required if api_key_name is not specified.
+  api_key_name 'stripe', -- The Key Name from above, required if api_key_id is not specified.
+  api_url 'https://api.stripe.com/v1/', -- Stripe API base URL, optional. Default is 'https://api.stripe.com/v1/'
+  api_version '2024-06-20' -- Stripe API version, optional. Default is your Stripe account’s default API version.
+);
+
+CREATE SCHEMA stripe;
+
+-- https://supabase.com/docs/guides/database/extensions/wrappers/stripe#checkout-sessions
+CREATE FOREIGN TABLE stripe.checkout_sessions (id text, customer text, payment_intent text, subscription text, attrs jsonb) server stripe_server options (object 'checkout/sessions', rowid_column 'id');

--- a/packages/common/data/supabase/migrations/20240904185013_add_stripe_wrapper.sql
+++ b/packages/common/data/supabase/migrations/20240904185013_add_stripe_wrapper.sql
@@ -15,10 +15,10 @@ values (
 returning key_id;
 */
 CREATE SERVER stripe_server FOREIGN data wrapper stripe_wrapper options (
-  api_key_id '89fec8a6-bc72-4b89-a8f6-09f4539d7ce5', -- The Key ID from above, required if api_key_name is not specified.
-  api_key_name 'stripe', -- The Key Name from above, required if api_key_id is not specified.
-  api_url 'https://api.stripe.com/v1/', -- Stripe API base URL, optional. Default is 'https://api.stripe.com/v1/'
-  api_version '2024-06-20' -- Stripe API version, optional. Default is your Stripe account’s default API version.
+  api_key_id '89fec8a6-bc72-4b89-a8f6-09f4539d7ce5',
+  api_key_name 'stripe',
+  api_url 'https://api.stripe.com/v1/',
+  api_version '2024-06-20'
 );
 
 CREATE SCHEMA stripe;

--- a/packages/common/data/supabase/tests/stripe/rls_test_as_anon.sql
+++ b/packages/common/data/supabase/tests/stripe/rls_test_as_anon.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+SELECT
+  dbdev.install ('basejump-supabase_test_helpers');
+
+CREATE EXTENSION "basejump-supabase_test_helpers"
+WITH
+  schema extensions;
+
+SELECT
+  tests.clear_authentication ();
+
+SELECT
+  plan (1);
+
+SELECT
+  throws_ok (
+    'SELECT * FROM stripe.checkout_sessions',
+    '42501',
+    'permission denied for schema stripe',
+    '未認証ユーザは stripe.checkout_sessions を参照できないこと'
+  );
+
+SELECT
+  *
+FROM
+  finish ();
+
+ROLLBACK;

--- a/packages/common/data/supabase/tests/stripe/rls_test_as_authenticated.sql
+++ b/packages/common/data/supabase/tests/stripe/rls_test_as_authenticated.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+SELECT
+  dbdev.install ('basejump-supabase_test_helpers');
+
+CREATE EXTENSION "basejump-supabase_test_helpers"
+WITH
+  schema extensions;
+
+--　事前準備: サンプルユーザを作成
+DELETE FROM profiles;
+
+-- 一般ユーザ
+SELECT
+  tests.create_supabase_user ('sample_user', 'example@example.com', '555-555-5555');
+
+SELECT
+  tests.authenticate_as ('sample_user');
+
+SELECT
+  plan (1);
+
+SELECT
+  throws_ok (
+    'SELECT * FROM stripe.checkout_sessions',
+    '42501',
+    'permission denied for schema stripe',
+    '認証済みユーザは stripe.checkout_sessions を参照できないこと'
+  );
+
+SELECT
+  *
+FROM
+  finish ();
+
+ROLLBACK;

--- a/packages/common/data/supabase/tests/stripe/stripe_basic_test.sql
+++ b/packages/common/data/supabase/tests/stripe/stripe_basic_test.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+SELECT
+  dbdev.install ('basejump-supabase_test_helpers');
+
+CREATE EXTENSION "basejump-supabase_test_helpers"
+WITH
+  schema extensions;
+
+SELECT
+  plan (1);
+
+SELECT
+  has_foreign_table ('stripe', 'checkout_sessions', 'checkout_sessions テーブルが存在すること');
+
+SELECT
+  *
+FROM
+  finish ();
+
+ROLLBACK;


### PR DESCRIPTION
## 説明

- Stripe Data Connectのセットアップをしました
  - `stripe.checkout_sessions`テーブルを作成しました
    - cf. https://supabase.com/docs/guides/database/extensions/wrappers/stripe#checkout-sessions 
  - `stripe schema`に作成されているため、Service Role以外ではアクセスできません
    - Unit Testで確認しています

