### PR TITLE
[App] セッション詳細画面の実装

### DIFF
--- a/apps/app/lib/routing/router.dart
+++ b/apps/app/lib/routing/router.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_cores_settings/routing.dart';
 import 'package:conference_2024_app/main_page.dart';
 import 'package:flutter/foundation.dart';

--- a/apps/app/lib/routing/routes/main/sessions/sessions_shell_branch.dart
+++ b/apps/app/lib/routing/routes/main/sessions/sessions_shell_branch.dart
@@ -24,7 +24,11 @@ class SessionsPageRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const SessionsPage();
+    return SessionsPage(
+      onTapSession: (id) => unawaited(
+        SessionPageRoute(sessionId: id).push(context),
+      ),
+    );
   }
 }
 

--- a/apps/app/lib/routing/routes/main/sessions/sessions_shell_branch.dart
+++ b/apps/app/lib/routing/routes/main/sessions/sessions_shell_branch.dart
@@ -45,8 +45,6 @@ class SessionPageRoute extends GoRouteData {
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return SessionPage(
-      sessionId: sessionId,
-    );
+    return const SessionPage();
   }
 }

--- a/packages/app/cores/designsystem/lib/src/theme.dart
+++ b/packages/app/cores/designsystem/lib/src/theme.dart
@@ -13,11 +13,14 @@ ThemeData theme(ThemeRef ref, ColorScheme? colorScheme) {
   );
   final baseTheme = ThemeData.from(
     colorScheme: colorScheme ?? defaultLightScheme,
+    useMaterial3: true,
   );
 
-  return _setFontFamily(
-    baseTheme: baseTheme,
-    fontFamily: fontFamily,
+  return _setDefaults(
+    baseTheme: _setFontFamily(
+      baseTheme: baseTheme,
+      fontFamily: fontFamily,
+    ),
   );
 }
 
@@ -30,15 +33,25 @@ ThemeData darkTheme(DarkThemeRef ref, ColorScheme? colorScheme) {
   );
   final baseTheme = ThemeData.from(
     colorScheme: colorScheme ?? defaultDarkColorScheme,
+    useMaterial3: true,
   );
 
-  return _setFontFamily(
-    baseTheme: baseTheme,
-    fontFamily: fontFamily,
+  return _setDefaults(
+    baseTheme: _setFontFamily(
+      baseTheme: baseTheme,
+      fontFamily: fontFamily,
+    ),
   );
 }
 
 const _seedColor = Color(0xFF005AC1);
+
+ThemeData _setDefaults({
+  required ThemeData baseTheme,
+}) =>
+    baseTheme.copyWith(
+      splashFactory: InkSparkle.splashFactory,
+    );
 
 ThemeData _setFontFamily({
   required ThemeData baseTheme,

--- a/packages/app/features/session/assets/l10n/app_en.arb
+++ b/packages/app/features/session/assets/l10n/app_en.arb
@@ -1,4 +1,7 @@
 {
+  "openSpeakersLink": "Open speaker's link",
+  "registerToCalendar": "Register schedule to calendar",
+  "sessionPageTitle": "Session",
   "sessionsPageTitle": "Sessions",
-  "sessionPageTitle": "Session"
+  "shareOnX": "Share on X"
 }

--- a/packages/app/features/session/assets/l10n/app_ja.arb
+++ b/packages/app/features/session/assets/l10n/app_ja.arb
@@ -1,4 +1,7 @@
 {
+  "openSpeakersLink": "登壇者情報を見る",
+  "registerToCalendar": "スケジュールをカレンダーに登録する",
+  "sessionPageTitle": "Session",
   "sessionsPageTitle": "Sessions",
-  "sessionPageTitle": "Session"
+  "shareOnX": "Xで共有する"
 }

--- a/packages/app/features/session/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n.dart
@@ -98,17 +98,35 @@ abstract class L10nSession {
     Locale('en')
   ];
 
-  /// No description provided for @sessionsPageTitle.
+  /// No description provided for @openSpeakersLink.
   ///
   /// In ja, this message translates to:
-  /// **'Sessions'**
-  String get sessionsPageTitle;
+  /// **'登壇者情報を見る'**
+  String get openSpeakersLink;
+
+  /// No description provided for @registerToCalendar.
+  ///
+  /// In ja, this message translates to:
+  /// **'スケジュールをカレンダーに登録する'**
+  String get registerToCalendar;
 
   /// No description provided for @sessionPageTitle.
   ///
   /// In ja, this message translates to:
   /// **'Session'**
   String get sessionPageTitle;
+
+  /// No description provided for @sessionsPageTitle.
+  ///
+  /// In ja, this message translates to:
+  /// **'Sessions'**
+  String get sessionsPageTitle;
+
+  /// No description provided for @shareOnX.
+  ///
+  /// In ja, this message translates to:
+  /// **'Xで共有する'**
+  String get shareOnX;
 }
 
 class _L10nSessionDelegate extends LocalizationsDelegate<L10nSession> {

--- a/packages/app/features/session/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n_en.dart
@@ -7,8 +7,17 @@ class L10nSessionEn extends L10nSession {
   L10nSessionEn([String locale = 'en']) : super(locale);
 
   @override
-  String get sessionsPageTitle => 'Sessions';
+  String get openSpeakersLink => 'Open speaker\'s link';
+
+  @override
+  String get registerToCalendar => 'Register schedule to calendar';
 
   @override
   String get sessionPageTitle => 'Session';
+
+  @override
+  String get sessionsPageTitle => 'Sessions';
+
+  @override
+  String get shareOnX => 'Share on X';
 }

--- a/packages/app/features/session/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n_ja.dart
@@ -7,8 +7,17 @@ class L10nSessionJa extends L10nSession {
   L10nSessionJa([String locale = 'ja']) : super(locale);
 
   @override
-  String get sessionsPageTitle => 'Sessions';
+  String get openSpeakersLink => '登壇者情報を見る';
+
+  @override
+  String get registerToCalendar => 'スケジュールをカレンダーに登録する';
 
   @override
   String get sessionPageTitle => 'Session';
+
+  @override
+  String get sessionsPageTitle => 'Sessions';
+
+  @override
+  String get shareOnX => 'Xで共有する';
 }

--- a/packages/app/features/session/lib/src/ui/bordered_icon_image.dart
+++ b/packages/app/features/session/lib/src/ui/bordered_icon_image.dart
@@ -1,0 +1,41 @@
+import 'package:app_cores_designsystem/ui.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class BorderedIconImage extends StatelessWidget {
+  const BorderedIconImage({
+    required this.size,
+    super.key,
+  });
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: theme.colorScheme.secondary,
+        ),
+        borderRadius: BorderRadius.circular(12),
+        image: DecorationImage(
+          image: NetworkImage(
+            'https://via.placeholder.com/$size',
+          ),
+          onError: (exception, stackTrace) => MainLogo(size: size),
+        ),
+      ),
+      child: SizedBox(
+        height: size,
+        width: size,
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('size', size));
+  }
+}

--- a/packages/app/features/session/lib/src/ui/session_item.dart
+++ b/packages/app/features/session/lib/src/ui/session_item.dart
@@ -8,14 +8,17 @@ class SessionItem extends StatelessWidget {
     required String title,
     required String name,
     required bool isDateVisible,
+    required VoidCallback? onTap,
     super.key,
   })  : _title = title,
         _name = name,
-        _isDateVisible = isDateVisible;
+        _isDateVisible = isDateVisible,
+        _onTap = onTap;
 
   final String _title;
   final String _name;
   final bool _isDateVisible;
+  final VoidCallback? _onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -47,6 +50,7 @@ class SessionItem extends StatelessWidget {
             ),
             child: Card(
               elevation: 0,
+              color: theme.colorScheme.surface,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),
                 side: BorderSide(
@@ -55,6 +59,7 @@ class SessionItem extends StatelessWidget {
               ),
               clipBehavior: Clip.antiAlias,
               child: ListTile(
+                onTap: _onTap,
                 contentPadding: const EdgeInsets.symmetric(
                   horizontal: 16,
                   vertical: 16,

--- a/packages/app/features/session/lib/src/ui/session_item.dart
+++ b/packages/app/features/session/lib/src/ui/session_item.dart
@@ -22,11 +22,11 @@ class SessionItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.only(
         right: 16,
         left: 8,
+        top: 8,
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -48,96 +48,131 @@ class SessionItem extends StatelessWidget {
                 ),
               ),
             ),
-            child: Card(
-              elevation: 0,
-              color: theme.colorScheme.surface,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-                side: BorderSide(
-                  color: theme.colorScheme.outline,
-                ),
-              ),
-              clipBehavior: Clip.antiAlias,
-              child: ListTile(
-                onTap: _onTap,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 16,
-                ),
-                title: Text(
-                  _title,
-                  style: theme.textTheme.titleMedium,
-                ),
-                subtitle: Column(
+            child: _SessionCard(
+              title: _title,
+              name: _name,
+              onTap: _onTap,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SessionCard extends StatelessWidget {
+  const _SessionCard({
+    required String title,
+    required String name,
+    required VoidCallback? onTap,
+  })  : _title = title,
+        _name = name,
+        _onTap = onTap;
+
+  final String _title;
+  final String _name;
+  final VoidCallback? _onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(
+          color: theme.colorScheme.outline,
+        ),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Stack(
+        children: [
+          ListTile(
+            onTap: _onTap,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 16,
+            ),
+            title: Text(
+              _title,
+              style: theme.textTheme.titleMedium,
+            ),
+            subtitle: Column(
+              children: [
+                const Gap(8),
+                Row(
                   children: [
-                    const Gap(8),
-                    Row(
-                      children: [
-                        ClipRRect(
-                          borderRadius: BorderRadius.circular(12),
-                          child: Image.network(
-                            height: 40,
-                            width: 40,
-                            'https://flutterkaigi.jp/2023/assets/assets/flutterkaigi_logo_shadowed.svg',
-                            errorBuilder: (context, error, stackTrace) {
-                              return const MainLogo();
-                            },
+                    DecoratedBox(
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: theme.colorScheme.secondary,
+                        ),
+                        borderRadius: BorderRadius.circular(12),
+                        image: DecorationImage(
+                          image: const NetworkImage(
+                            'https://via.placeholder.com/40',
                           ),
+                          onError: (exception, stackTrace) =>
+                              const MainLogo(size: 40),
                         ),
-                        const Gap(8),
-                        Text(
-                          _name,
-                          style: theme.textTheme.labelMedium,
-                        ),
-                      ],
+                      ),
+                      child: const SizedBox(height: 40, width: 40),
                     ),
                     const Gap(8),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Row(
-                          children: [
-                            Container(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 12),
-                              height: 28,
-                              decoration: BoxDecoration(
-                                color: theme.colorScheme.primaryFixedDim,
-                                borderRadius: BorderRadius.circular(25),
-                              ),
-                              child: Center(
-                                child: Text(
-                                  'DevOps',
-                                  style: theme.textTheme.labelSmall,
-                                ),
-                              ),
-                            ),
-                            const Gap(8),
-                            Container(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 12),
-                              height: 28,
-                              decoration: BoxDecoration(
-                                color: theme.colorScheme.tertiaryFixedDim,
-                                borderRadius: BorderRadius.circular(25),
-                              ),
-                              child: Center(
-                                child: Text(
-                                  'Room1',
-                                  style: theme.textTheme.labelSmall,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                        const Icon(
-                          Icons.bookmark_outline,
-                        ),
-                      ],
+                    Text(
+                      _name,
+                      style: theme.textTheme.labelMedium,
                     ),
                   ],
                 ),
+                const Gap(8),
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      height: 28,
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primaryFixedDim,
+                        borderRadius: BorderRadius.circular(25),
+                      ),
+                      child: Center(
+                        child: Text(
+                          'DevOps',
+                          style: theme.textTheme.labelSmall,
+                        ),
+                      ),
+                    ),
+                    const Gap(8),
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      height: 28,
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.tertiaryFixedDim,
+                        borderRadius: BorderRadius.circular(25),
+                      ),
+                      child: Center(
+                        child: Text(
+                          'Room1',
+                          style: theme.textTheme.labelSmall,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            right: 0,
+            bottom: 0,
+            child: IconButton(
+              padding: const EdgeInsets.all(12),
+              icon: const Icon(
+                Icons.bookmark_outline,
               ),
+              onPressed: () {},
             ),
           ),
         ],

--- a/packages/app/features/session/lib/src/ui/session_item.dart
+++ b/packages/app/features/session/lib/src/ui/session_item.dart
@@ -1,9 +1,11 @@
-import 'package:app_cores_designsystem/ui.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
+import 'package:packages_app_features_session/src/ui/bordered_icon_image.dart';
+import 'package:packages_app_features_session/src/ui/session_room_chip.dart';
 
 /// タイムラインのアイテム
 class SessionItem extends StatelessWidget {
+  // FIXME: セッションデータの設計が終わったらidを引数にする
   const SessionItem({
     required String title,
     required String name,
@@ -104,22 +106,7 @@ class _SessionCard extends StatelessWidget {
                 const Gap(8),
                 Row(
                   children: [
-                    DecoratedBox(
-                      decoration: BoxDecoration(
-                        border: Border.all(
-                          color: theme.colorScheme.secondary,
-                        ),
-                        borderRadius: BorderRadius.circular(12),
-                        image: DecorationImage(
-                          image: const NetworkImage(
-                            'https://via.placeholder.com/40',
-                          ),
-                          onError: (exception, stackTrace) =>
-                              const MainLogo(size: 40),
-                        ),
-                      ),
-                      child: const SizedBox(height: 40, width: 40),
-                    ),
+                    const BorderedIconImage(size: 40),
                     const Gap(8),
                     Text(
                       _name,
@@ -145,20 +132,7 @@ class _SessionCard extends StatelessWidget {
                       ),
                     ),
                     const Gap(8),
-                    Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
-                      height: 28,
-                      decoration: BoxDecoration(
-                        color: theme.colorScheme.tertiaryFixedDim,
-                        borderRadius: BorderRadius.circular(25),
-                      ),
-                      child: Center(
-                        child: Text(
-                          'Room1',
-                          style: theme.textTheme.labelSmall,
-                        ),
-                      ),
-                    ),
+                    const SessionRoomChip(),
                   ],
                 ),
               ],

--- a/packages/app/features/session/lib/src/ui/session_page.dart
+++ b/packages/app/features/session/lib/src/ui/session_page.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:app_cores_core/util.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:packages_app_features_session/l10n.dart';
@@ -13,8 +16,20 @@ class SessionPage extends StatelessWidget {
     return Scaffold(
       body: CustomScrollView(
         slivers: [
-          const SliverAppBar.large(
-            title: Text('Example Super Session Title ~ Why we using Flutter?'),
+          SliverAppBar.large(
+            title: const Text(
+              'Example Super Session Title ~ Why we using Flutter?',
+            ),
+            actions: [
+              IconButton(
+                tooltip: l.shareOnX,
+                padding: const EdgeInsets.all(12),
+                onPressed: () {
+                  // TODO: データをつなぎこんだら共有機能を実装する
+                },
+                icon: const Icon(Icons.share),
+              ),
+            ],
           ),
           SliverList.list(
             children: [
@@ -25,14 +40,20 @@ class SessionPage extends StatelessWidget {
                 ],
               ),
               const Gap(8),
-              ListTile(
-                contentPadding: const EdgeInsets.symmetric(
-                  vertical: 8,
-                  horizontal: 16,
+              Tooltip(
+                message: l.openSpeakersLink,
+                child: ListTile(
+                  contentPadding: const EdgeInsets.symmetric(
+                    vertical: 8,
+                    horizontal: 16,
+                  ),
+                  leading: const BorderedIconImage(size: 56),
+                  title: const Text('John Doe'),
+                  onTap: () {
+                    final url = Uri.parse('https://twitter.com/FlutterKaigi');
+                    unawaited(launchInExternalApp(url));
+                  },
                 ),
-                leading: const BorderedIconImage(size: 56),
-                title: const Text('John Doe'),
-                onTap: () {},
               ),
               const Gap(8),
               Padding(
@@ -42,6 +63,21 @@ class SessionPage extends StatelessWidget {
                   'printing and typesetting industry. '
                   'Lorem Ipsum has been the industry',
                   style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+              const Gap(8),
+              // TODO: データをつなぎこんだら日時を下記の形式にフォーマットする
+              Tooltip(
+                message: l.registerToCalendar,
+                child: ListTile(
+                  title: Text(
+                    'Day1 14:00~15:00',
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                  leading: const Icon(Icons.event_outlined),
+                  onTap: () {
+                    // TODO: 該当の日時でカレンダーを開く
+                  },
                 ),
               ),
             ],

--- a/packages/app/features/session/lib/src/ui/session_page.dart
+++ b/packages/app/features/session/lib/src/ui/session_page.dart
@@ -1,21 +1,52 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
 import 'package:packages_app_features_session/l10n.dart';
+import 'package:packages_app_features_session/src/ui/bordered_icon_image.dart';
+import 'package:packages_app_features_session/src/ui/session_room_chip.dart';
 
 class SessionPage extends StatelessWidget {
-  const SessionPage({
-    required String sessionId,
-    super.key,
-  }) : _sessionId = sessionId;
-
-  final String _sessionId;
+  const SessionPage({super.key});
 
   @override
   Widget build(BuildContext context) {
     final l = L10nSession.of(context);
     return Scaffold(
-      appBar: AppBar(),
-      body: Center(
-        child: Text('${l.sessionPageTitle}: $_sessionId'),
+      body: CustomScrollView(
+        slivers: [
+          const SliverAppBar.large(
+            title: Text('Example Super Session Title ~ Why we using Flutter?'),
+          ),
+          SliverList.list(
+            children: [
+              const Row(
+                children: [
+                  Gap(16),
+                  SessionRoomChip(),
+                ],
+              ),
+              const Gap(8),
+              ListTile(
+                contentPadding: const EdgeInsets.symmetric(
+                  vertical: 8,
+                  horizontal: 16,
+                ),
+                leading: const BorderedIconImage(size: 56),
+                title: const Text('John Doe'),
+                onTap: () {},
+              ),
+              const Gap(8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  'FlutterKaigi is Lorem Ipsum is simply dummy text of the '
+                  'printing and typesetting industry. '
+                  'Lorem Ipsum has been the industry',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/packages/app/features/session/lib/src/ui/session_room_chip.dart
+++ b/packages/app/features/session/lib/src/ui/session_room_chip.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class SessionRoomChip extends StatelessWidget {
+  const SessionRoomChip({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      height: 28,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.tertiaryFixedDim,
+        borderRadius: BorderRadius.circular(25),
+      ),
+      child: Center(
+        child: Text(
+          'Room1',
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onTertiaryFixed,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/app/features/session/lib/src/ui/sessions_page.dart
+++ b/packages/app/features/session/lib/src/ui/sessions_page.dart
@@ -1,16 +1,18 @@
-import 'dart:ffi';
-
 import 'package:app_cores_designsystem/ui.dart';
 import 'package:app_cores_settings/ui.dart';
 import 'package:flutter/material.dart';
-import 'package:gap/gap.dart';
 import 'package:packages_app_features_session/l10n.dart';
 import 'package:packages_app_features_session/src/ui/session_item.dart';
 
+typedef OnTapSessionCallback = void Function(String sessionId);
+
 class SessionsPage extends StatelessWidget {
   const SessionsPage({
+    required OnTapSessionCallback onTapSession,
     super.key,
-  });
+  }) : _onTapSession = onTapSession;
+
+  final OnTapSessionCallback _onTapSession;
 
   @override
   Widget build(BuildContext context) {
@@ -31,10 +33,11 @@ class SessionsPage extends StatelessWidget {
           SliverList(
             delegate: SliverChildBuilderDelegate(
               (context, index) {
-                return const SessionItem(
+                return SessionItem(
                   title: 'Example Super Session Title ~ Why we using Flutter?',
                   name: 'Name',
                   isDateVisible: true,
+                  onTap: () => _onTapSession('id'),
                 );
               },
             ),

--- a/packages/app/features/session/pubspec.lock
+++ b/packages/app/features/session/pubspec.lock
@@ -2,7 +2,7 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   app_cores_core:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: "../../cores/core"
       relative: true

--- a/packages/app/features/session/pubspec.yaml
+++ b/packages/app/features/session/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: ^3.23.0-13.0.pre
 
 dependencies:
+  app_cores_core:
   app_cores_designsystem:
   app_cores_settings:
     path: ../../cores/settings


### PR DESCRIPTION
## Issue

- Closes #25
- Closes #22

## 説明

- セッションカードのデザイン修正・リファクタリング
- セッション詳細画面のコンテンツ実装
  - お気に入り登録は別PRにて

## 画像 / 動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
|-|-|-|
| | | |

## その他

実装につき、Figmaも少し修正してます（Xの共有とカレンダー登録の導線がメニューボタンにまとまっていたのをバラし、カレンダー登録はセッションのdescriptionの下に配置するようにしました）。
