### PR TITLE
[data] セッション関連のRepositoryを作成

### DIFF
--- a/packages/common/data/lib/session.dart
+++ b/packages/common/data/lib/session.dart
@@ -1,0 +1,13 @@
+export 'src/model/session.dart' show Session;
+export 'src/model/session_speaker.dart' show SessionSpeaker;
+export 'src/model/session_venue.dart' show SessionVenue;
+export 'src/model/view/session_venues_with_sessions.dart'
+    show SessionVenuesWithSessions;
+export 'src/repository/session_repository.dart'
+    show
+        SessionRepository,
+        SessionSpeakerRepository,
+        SessionVenueRepository,
+        sessionRepositoryProvider,
+        sessionSpeakerRepositoryProvider,
+        sessionVenueRepositoryProvider;

--- a/packages/common/data/lib/session.dart
+++ b/packages/common/data/lib/session.dart
@@ -1,6 +1,10 @@
+export 'src/model/profile_social_networking_service.dart'
+    show ProfileSocialNetworkingService;
 export 'src/model/session.dart' show Session;
 export 'src/model/session_speaker.dart' show SessionSpeaker;
 export 'src/model/session_venue.dart' show SessionVenue;
+export 'src/model/sns.dart' show SnsType;
+export 'src/model/view/profile_with_sns.dart' show ProfileWithSns;
 export 'src/model/view/session_venues_with_sessions.dart'
     show SessionVenuesWithSessions;
 export 'src/repository/session_repository.dart'

--- a/packages/common/data/lib/src/model/profile_social_networking_service.dart
+++ b/packages/common/data/lib/src/model/profile_social_networking_service.dart
@@ -1,0 +1,20 @@
+import 'package:common_data/src/model/sns.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'profile_social_networking_service.freezed.dart';
+part 'profile_social_networking_service.g.dart';
+
+@freezed
+class ProfileSocialNetworkingService with _$ProfileSocialNetworkingService {
+  const factory ProfileSocialNetworkingService({
+    required String id,
+    required SnsType type,
+    required String value,
+  }) = _ProfileSocialNetworkingService;
+
+  factory ProfileSocialNetworkingService.fromJson(Map<String, dynamic> json) =>
+    _$ProfileSocialNetworkingServiceFromJson(json);
+}
+
+
+

--- a/packages/common/data/lib/src/model/profile_social_networking_service.dart
+++ b/packages/common/data/lib/src/model/profile_social_networking_service.dart
@@ -13,8 +13,5 @@ class ProfileSocialNetworkingService with _$ProfileSocialNetworkingService {
   }) = _ProfileSocialNetworkingService;
 
   factory ProfileSocialNetworkingService.fromJson(Map<String, dynamic> json) =>
-    _$ProfileSocialNetworkingServiceFromJson(json);
+      _$ProfileSocialNetworkingServiceFromJson(json);
 }
-
-
-

--- a/packages/common/data/lib/src/model/profile_social_networking_service.freezed.dart
+++ b/packages/common/data/lib/src/model/profile_social_networking_service.freezed.dart
@@ -1,0 +1,213 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'profile_social_networking_service.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ProfileSocialNetworkingService _$ProfileSocialNetworkingServiceFromJson(
+    Map<String, dynamic> json) {
+  return _ProfileSocialNetworkingService.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ProfileSocialNetworkingService {
+  String get id => throw _privateConstructorUsedError;
+  SnsType get type => throw _privateConstructorUsedError;
+  String get value => throw _privateConstructorUsedError;
+
+  /// Serializes this ProfileSocialNetworkingService to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ProfileSocialNetworkingService
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ProfileSocialNetworkingServiceCopyWith<ProfileSocialNetworkingService>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ProfileSocialNetworkingServiceCopyWith<$Res> {
+  factory $ProfileSocialNetworkingServiceCopyWith(
+          ProfileSocialNetworkingService value,
+          $Res Function(ProfileSocialNetworkingService) then) =
+      _$ProfileSocialNetworkingServiceCopyWithImpl<$Res,
+          ProfileSocialNetworkingService>;
+  @useResult
+  $Res call({String id, SnsType type, String value});
+}
+
+/// @nodoc
+class _$ProfileSocialNetworkingServiceCopyWithImpl<$Res,
+        $Val extends ProfileSocialNetworkingService>
+    implements $ProfileSocialNetworkingServiceCopyWith<$Res> {
+  _$ProfileSocialNetworkingServiceCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ProfileSocialNetworkingService
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? type = null,
+    Object? value = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as SnsType,
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ProfileSocialNetworkingServiceImplCopyWith<$Res>
+    implements $ProfileSocialNetworkingServiceCopyWith<$Res> {
+  factory _$$ProfileSocialNetworkingServiceImplCopyWith(
+          _$ProfileSocialNetworkingServiceImpl value,
+          $Res Function(_$ProfileSocialNetworkingServiceImpl) then) =
+      __$$ProfileSocialNetworkingServiceImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String id, SnsType type, String value});
+}
+
+/// @nodoc
+class __$$ProfileSocialNetworkingServiceImplCopyWithImpl<$Res>
+    extends _$ProfileSocialNetworkingServiceCopyWithImpl<$Res,
+        _$ProfileSocialNetworkingServiceImpl>
+    implements _$$ProfileSocialNetworkingServiceImplCopyWith<$Res> {
+  __$$ProfileSocialNetworkingServiceImplCopyWithImpl(
+      _$ProfileSocialNetworkingServiceImpl _value,
+      $Res Function(_$ProfileSocialNetworkingServiceImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ProfileSocialNetworkingService
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? type = null,
+    Object? value = null,
+  }) {
+    return _then(_$ProfileSocialNetworkingServiceImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as SnsType,
+      value: null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ProfileSocialNetworkingServiceImpl
+    implements _ProfileSocialNetworkingService {
+  const _$ProfileSocialNetworkingServiceImpl(
+      {required this.id, required this.type, required this.value});
+
+  factory _$ProfileSocialNetworkingServiceImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$ProfileSocialNetworkingServiceImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final SnsType type;
+  @override
+  final String value;
+
+  @override
+  String toString() {
+    return 'ProfileSocialNetworkingService(id: $id, type: $type, value: $value)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ProfileSocialNetworkingServiceImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.value, value) || other.value == value));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, type, value);
+
+  /// Create a copy of ProfileSocialNetworkingService
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ProfileSocialNetworkingServiceImplCopyWith<
+          _$ProfileSocialNetworkingServiceImpl>
+      get copyWith => __$$ProfileSocialNetworkingServiceImplCopyWithImpl<
+          _$ProfileSocialNetworkingServiceImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ProfileSocialNetworkingServiceImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ProfileSocialNetworkingService
+    implements ProfileSocialNetworkingService {
+  const factory _ProfileSocialNetworkingService(
+      {required final String id,
+      required final SnsType type,
+      required final String value}) = _$ProfileSocialNetworkingServiceImpl;
+
+  factory _ProfileSocialNetworkingService.fromJson(Map<String, dynamic> json) =
+      _$ProfileSocialNetworkingServiceImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  SnsType get type;
+  @override
+  String get value;
+
+  /// Create a copy of ProfileSocialNetworkingService
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ProfileSocialNetworkingServiceImplCopyWith<
+          _$ProfileSocialNetworkingServiceImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/common/data/lib/src/model/profile_social_networking_service.g.dart
+++ b/packages/common/data/lib/src/model/profile_social_networking_service.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'profile_social_networking_service.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ProfileSocialNetworkingServiceImpl
+    _$$ProfileSocialNetworkingServiceImplFromJson(Map<String, dynamic> json) =>
+        $checkedCreate(
+          r'_$ProfileSocialNetworkingServiceImpl',
+          json,
+          ($checkedConvert) {
+            final val = _$ProfileSocialNetworkingServiceImpl(
+              id: $checkedConvert('id', (v) => v as String),
+              type: $checkedConvert(
+                  'type', (v) => $enumDecode(_$SnsTypeEnumMap, v)),
+              value: $checkedConvert('value', (v) => v as String),
+            );
+            return val;
+          },
+        );
+
+Map<String, dynamic> _$$ProfileSocialNetworkingServiceImplToJson(
+        _$ProfileSocialNetworkingServiceImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'type': _$SnsTypeEnumMap[instance.type]!,
+      'value': instance.value,
+    };
+
+const _$SnsTypeEnumMap = {
+  SnsType.github: 'github',
+  SnsType.x: 'x',
+  SnsType.discord: 'discord',
+  SnsType.medium: 'medium',
+  SnsType.qiita: 'qiita',
+  SnsType.zenn: 'zenn',
+  SnsType.note: 'note',
+  SnsType.other: 'other',
+};

--- a/packages/common/data/lib/src/model/session.dart
+++ b/packages/common/data/lib/src/model/session.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'session.freezed.dart';
+part 'session.g.dart';
+
+@freezed
+class Session with _$Session {
+  const factory Session({
+    required String id,
+    required String title,
+    required String description,
+    required DateTime startsAt,
+    required DateTime endsAt,
+    required String venueId,
+    required int? sponsorId,
+    required bool isLightningTalk,
+    required DateTime createdAt,
+  }) = _Session;
+
+  factory Session.fromJson(Map<String, dynamic> json) =>
+      _$SessionFromJson(json);
+}

--- a/packages/common/data/lib/src/model/session.freezed.dart
+++ b/packages/common/data/lib/src/model/session.freezed.dart
@@ -1,0 +1,330 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'session.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Session _$SessionFromJson(Map<String, dynamic> json) {
+  return _Session.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Session {
+  String get id => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String get description => throw _privateConstructorUsedError;
+  DateTime get startsAt => throw _privateConstructorUsedError;
+  DateTime get endsAt => throw _privateConstructorUsedError;
+  String get venueId => throw _privateConstructorUsedError;
+  int? get sponsorId => throw _privateConstructorUsedError;
+  bool get isLightningTalk => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+
+  /// Serializes this Session to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SessionCopyWith<Session> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SessionCopyWith<$Res> {
+  factory $SessionCopyWith(Session value, $Res Function(Session) then) =
+      _$SessionCopyWithImpl<$Res, Session>;
+  @useResult
+  $Res call(
+      {String id,
+      String title,
+      String description,
+      DateTime startsAt,
+      DateTime endsAt,
+      String venueId,
+      int? sponsorId,
+      bool isLightningTalk,
+      DateTime createdAt});
+}
+
+/// @nodoc
+class _$SessionCopyWithImpl<$Res, $Val extends Session>
+    implements $SessionCopyWith<$Res> {
+  _$SessionCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? description = null,
+    Object? startsAt = null,
+    Object? endsAt = null,
+    Object? venueId = null,
+    Object? sponsorId = freezed,
+    Object? isLightningTalk = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      startsAt: null == startsAt
+          ? _value.startsAt
+          : startsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      endsAt: null == endsAt
+          ? _value.endsAt
+          : endsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      venueId: null == venueId
+          ? _value.venueId
+          : venueId // ignore: cast_nullable_to_non_nullable
+              as String,
+      sponsorId: freezed == sponsorId
+          ? _value.sponsorId
+          : sponsorId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      isLightningTalk: null == isLightningTalk
+          ? _value.isLightningTalk
+          : isLightningTalk // ignore: cast_nullable_to_non_nullable
+              as bool,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SessionImplCopyWith<$Res> implements $SessionCopyWith<$Res> {
+  factory _$$SessionImplCopyWith(
+          _$SessionImpl value, $Res Function(_$SessionImpl) then) =
+      __$$SessionImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String title,
+      String description,
+      DateTime startsAt,
+      DateTime endsAt,
+      String venueId,
+      int? sponsorId,
+      bool isLightningTalk,
+      DateTime createdAt});
+}
+
+/// @nodoc
+class __$$SessionImplCopyWithImpl<$Res>
+    extends _$SessionCopyWithImpl<$Res, _$SessionImpl>
+    implements _$$SessionImplCopyWith<$Res> {
+  __$$SessionImplCopyWithImpl(
+      _$SessionImpl _value, $Res Function(_$SessionImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? description = null,
+    Object? startsAt = null,
+    Object? endsAt = null,
+    Object? venueId = null,
+    Object? sponsorId = freezed,
+    Object? isLightningTalk = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_$SessionImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      startsAt: null == startsAt
+          ? _value.startsAt
+          : startsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      endsAt: null == endsAt
+          ? _value.endsAt
+          : endsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      venueId: null == venueId
+          ? _value.venueId
+          : venueId // ignore: cast_nullable_to_non_nullable
+              as String,
+      sponsorId: freezed == sponsorId
+          ? _value.sponsorId
+          : sponsorId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      isLightningTalk: null == isLightningTalk
+          ? _value.isLightningTalk
+          : isLightningTalk // ignore: cast_nullable_to_non_nullable
+              as bool,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SessionImpl implements _Session {
+  const _$SessionImpl(
+      {required this.id,
+      required this.title,
+      required this.description,
+      required this.startsAt,
+      required this.endsAt,
+      required this.venueId,
+      required this.sponsorId,
+      required this.isLightningTalk,
+      required this.createdAt});
+
+  factory _$SessionImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SessionImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String title;
+  @override
+  final String description;
+  @override
+  final DateTime startsAt;
+  @override
+  final DateTime endsAt;
+  @override
+  final String venueId;
+  @override
+  final int? sponsorId;
+  @override
+  final bool isLightningTalk;
+  @override
+  final DateTime createdAt;
+
+  @override
+  String toString() {
+    return 'Session(id: $id, title: $title, description: $description, startsAt: $startsAt, endsAt: $endsAt, venueId: $venueId, sponsorId: $sponsorId, isLightningTalk: $isLightningTalk, createdAt: $createdAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SessionImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.startsAt, startsAt) ||
+                other.startsAt == startsAt) &&
+            (identical(other.endsAt, endsAt) || other.endsAt == endsAt) &&
+            (identical(other.venueId, venueId) || other.venueId == venueId) &&
+            (identical(other.sponsorId, sponsorId) ||
+                other.sponsorId == sponsorId) &&
+            (identical(other.isLightningTalk, isLightningTalk) ||
+                other.isLightningTalk == isLightningTalk) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, title, description, startsAt,
+      endsAt, venueId, sponsorId, isLightningTalk, createdAt);
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SessionImplCopyWith<_$SessionImpl> get copyWith =>
+      __$$SessionImplCopyWithImpl<_$SessionImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SessionImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Session implements Session {
+  const factory _Session(
+      {required final String id,
+      required final String title,
+      required final String description,
+      required final DateTime startsAt,
+      required final DateTime endsAt,
+      required final String venueId,
+      required final int? sponsorId,
+      required final bool isLightningTalk,
+      required final DateTime createdAt}) = _$SessionImpl;
+
+  factory _Session.fromJson(Map<String, dynamic> json) = _$SessionImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get title;
+  @override
+  String get description;
+  @override
+  DateTime get startsAt;
+  @override
+  DateTime get endsAt;
+  @override
+  String get venueId;
+  @override
+  int? get sponsorId;
+  @override
+  bool get isLightningTalk;
+  @override
+  DateTime get createdAt;
+
+  /// Create a copy of Session
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SessionImplCopyWith<_$SessionImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/common/data/lib/src/model/session.g.dart
+++ b/packages/common/data/lib/src/model/session.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'session.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SessionImpl _$$SessionImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$SessionImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$SessionImpl(
+          id: $checkedConvert('id', (v) => v as String),
+          title: $checkedConvert('title', (v) => v as String),
+          description: $checkedConvert('description', (v) => v as String),
+          startsAt:
+              $checkedConvert('starts_at', (v) => DateTime.parse(v as String)),
+          endsAt:
+              $checkedConvert('ends_at', (v) => DateTime.parse(v as String)),
+          venueId: $checkedConvert('venue_id', (v) => v as String),
+          sponsorId: $checkedConvert('sponsor_id', (v) => (v as num?)?.toInt()),
+          isLightningTalk:
+              $checkedConvert('is_lightning_talk', (v) => v as bool),
+          createdAt:
+              $checkedConvert('created_at', (v) => DateTime.parse(v as String)),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'startsAt': 'starts_at',
+        'endsAt': 'ends_at',
+        'venueId': 'venue_id',
+        'sponsorId': 'sponsor_id',
+        'isLightningTalk': 'is_lightning_talk',
+        'createdAt': 'created_at'
+      },
+    );
+
+Map<String, dynamic> _$$SessionImplToJson(_$SessionImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'starts_at': instance.startsAt.toIso8601String(),
+      'ends_at': instance.endsAt.toIso8601String(),
+      'venue_id': instance.venueId,
+      'sponsor_id': instance.sponsorId,
+      'is_lightning_talk': instance.isLightningTalk,
+      'created_at': instance.createdAt.toIso8601String(),
+    };

--- a/packages/common/data/lib/src/model/session_speaker.dart
+++ b/packages/common/data/lib/src/model/session_speaker.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'session_speaker.freezed.dart';
+part 'session_speaker.g.dart';
+
+@freezed
+class SessionSpeaker with _$SessionSpeaker {
+  const factory SessionSpeaker({
+    required String sessionId,
+    required String speakerId,
+  }) = _SessionSpeaker;
+
+  factory SessionSpeaker.fromJson(Map<String, dynamic> json) =>
+      _$SessionSpeakerFromJson(json);
+}

--- a/packages/common/data/lib/src/model/session_speaker.freezed.dart
+++ b/packages/common/data/lib/src/model/session_speaker.freezed.dart
@@ -1,0 +1,186 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'session_speaker.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+SessionSpeaker _$SessionSpeakerFromJson(Map<String, dynamic> json) {
+  return _SessionSpeaker.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SessionSpeaker {
+  String get sessionId => throw _privateConstructorUsedError;
+  String get speakerId => throw _privateConstructorUsedError;
+
+  /// Serializes this SessionSpeaker to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of SessionSpeaker
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SessionSpeakerCopyWith<SessionSpeaker> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SessionSpeakerCopyWith<$Res> {
+  factory $SessionSpeakerCopyWith(
+          SessionSpeaker value, $Res Function(SessionSpeaker) then) =
+      _$SessionSpeakerCopyWithImpl<$Res, SessionSpeaker>;
+  @useResult
+  $Res call({String sessionId, String speakerId});
+}
+
+/// @nodoc
+class _$SessionSpeakerCopyWithImpl<$Res, $Val extends SessionSpeaker>
+    implements $SessionSpeakerCopyWith<$Res> {
+  _$SessionSpeakerCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SessionSpeaker
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sessionId = null,
+    Object? speakerId = null,
+  }) {
+    return _then(_value.copyWith(
+      sessionId: null == sessionId
+          ? _value.sessionId
+          : sessionId // ignore: cast_nullable_to_non_nullable
+              as String,
+      speakerId: null == speakerId
+          ? _value.speakerId
+          : speakerId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SessionSpeakerImplCopyWith<$Res>
+    implements $SessionSpeakerCopyWith<$Res> {
+  factory _$$SessionSpeakerImplCopyWith(_$SessionSpeakerImpl value,
+          $Res Function(_$SessionSpeakerImpl) then) =
+      __$$SessionSpeakerImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String sessionId, String speakerId});
+}
+
+/// @nodoc
+class __$$SessionSpeakerImplCopyWithImpl<$Res>
+    extends _$SessionSpeakerCopyWithImpl<$Res, _$SessionSpeakerImpl>
+    implements _$$SessionSpeakerImplCopyWith<$Res> {
+  __$$SessionSpeakerImplCopyWithImpl(
+      _$SessionSpeakerImpl _value, $Res Function(_$SessionSpeakerImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SessionSpeaker
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sessionId = null,
+    Object? speakerId = null,
+  }) {
+    return _then(_$SessionSpeakerImpl(
+      sessionId: null == sessionId
+          ? _value.sessionId
+          : sessionId // ignore: cast_nullable_to_non_nullable
+              as String,
+      speakerId: null == speakerId
+          ? _value.speakerId
+          : speakerId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SessionSpeakerImpl implements _SessionSpeaker {
+  const _$SessionSpeakerImpl(
+      {required this.sessionId, required this.speakerId});
+
+  factory _$SessionSpeakerImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SessionSpeakerImplFromJson(json);
+
+  @override
+  final String sessionId;
+  @override
+  final String speakerId;
+
+  @override
+  String toString() {
+    return 'SessionSpeaker(sessionId: $sessionId, speakerId: $speakerId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SessionSpeakerImpl &&
+            (identical(other.sessionId, sessionId) ||
+                other.sessionId == sessionId) &&
+            (identical(other.speakerId, speakerId) ||
+                other.speakerId == speakerId));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, sessionId, speakerId);
+
+  /// Create a copy of SessionSpeaker
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SessionSpeakerImplCopyWith<_$SessionSpeakerImpl> get copyWith =>
+      __$$SessionSpeakerImplCopyWithImpl<_$SessionSpeakerImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SessionSpeakerImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SessionSpeaker implements SessionSpeaker {
+  const factory _SessionSpeaker(
+      {required final String sessionId,
+      required final String speakerId}) = _$SessionSpeakerImpl;
+
+  factory _SessionSpeaker.fromJson(Map<String, dynamic> json) =
+      _$SessionSpeakerImpl.fromJson;
+
+  @override
+  String get sessionId;
+  @override
+  String get speakerId;
+
+  /// Create a copy of SessionSpeaker
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SessionSpeakerImplCopyWith<_$SessionSpeakerImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/common/data/lib/src/model/session_speaker.g.dart
+++ b/packages/common/data/lib/src/model/session_speaker.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'session_speaker.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SessionSpeakerImpl _$$SessionSpeakerImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$SessionSpeakerImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$SessionSpeakerImpl(
+          sessionId: $checkedConvert('session_id', (v) => v as String),
+          speakerId: $checkedConvert('speaker_id', (v) => v as String),
+        );
+        return val;
+      },
+      fieldKeyMap: const {'sessionId': 'session_id', 'speakerId': 'speaker_id'},
+    );
+
+Map<String, dynamic> _$$SessionSpeakerImplToJson(
+        _$SessionSpeakerImpl instance) =>
+    <String, dynamic>{
+      'session_id': instance.sessionId,
+      'speaker_id': instance.speakerId,
+    };

--- a/packages/common/data/lib/src/model/session_venue.dart
+++ b/packages/common/data/lib/src/model/session_venue.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'session_venue.freezed.dart';
+part 'session_venue.g.dart';
+
+
+
+@freezed
+class SessionVenue with _$SessionVenue {
+  const factory SessionVenue({
+    required String id,
+    required String name,
+  }) = _SessionVenue;
+
+  factory SessionVenue.fromJson(Map<String, dynamic> json) =>
+      _$SessionVenueFromJson(json);
+}

--- a/packages/common/data/lib/src/model/session_venue.freezed.dart
+++ b/packages/common/data/lib/src/model/session_venue.freezed.dart
@@ -1,0 +1,182 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'session_venue.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+SessionVenue _$SessionVenueFromJson(Map<String, dynamic> json) {
+  return _SessionVenue.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SessionVenue {
+  String get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+
+  /// Serializes this SessionVenue to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of SessionVenue
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SessionVenueCopyWith<SessionVenue> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SessionVenueCopyWith<$Res> {
+  factory $SessionVenueCopyWith(
+          SessionVenue value, $Res Function(SessionVenue) then) =
+      _$SessionVenueCopyWithImpl<$Res, SessionVenue>;
+  @useResult
+  $Res call({String id, String name});
+}
+
+/// @nodoc
+class _$SessionVenueCopyWithImpl<$Res, $Val extends SessionVenue>
+    implements $SessionVenueCopyWith<$Res> {
+  _$SessionVenueCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SessionVenue
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SessionVenueImplCopyWith<$Res>
+    implements $SessionVenueCopyWith<$Res> {
+  factory _$$SessionVenueImplCopyWith(
+          _$SessionVenueImpl value, $Res Function(_$SessionVenueImpl) then) =
+      __$$SessionVenueImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String id, String name});
+}
+
+/// @nodoc
+class __$$SessionVenueImplCopyWithImpl<$Res>
+    extends _$SessionVenueCopyWithImpl<$Res, _$SessionVenueImpl>
+    implements _$$SessionVenueImplCopyWith<$Res> {
+  __$$SessionVenueImplCopyWithImpl(
+      _$SessionVenueImpl _value, $Res Function(_$SessionVenueImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SessionVenue
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+  }) {
+    return _then(_$SessionVenueImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SessionVenueImpl implements _SessionVenue {
+  const _$SessionVenueImpl({required this.id, required this.name});
+
+  factory _$SessionVenueImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SessionVenueImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String name;
+
+  @override
+  String toString() {
+    return 'SessionVenue(id: $id, name: $name)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SessionVenueImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name);
+
+  /// Create a copy of SessionVenue
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SessionVenueImplCopyWith<_$SessionVenueImpl> get copyWith =>
+      __$$SessionVenueImplCopyWithImpl<_$SessionVenueImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SessionVenueImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SessionVenue implements SessionVenue {
+  const factory _SessionVenue(
+      {required final String id,
+      required final String name}) = _$SessionVenueImpl;
+
+  factory _SessionVenue.fromJson(Map<String, dynamic> json) =
+      _$SessionVenueImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get name;
+
+  /// Create a copy of SessionVenue
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SessionVenueImplCopyWith<_$SessionVenueImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/common/data/lib/src/model/session_venue.g.dart
+++ b/packages/common/data/lib/src/model/session_venue.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'session_venue.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SessionVenueImpl _$$SessionVenueImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$SessionVenueImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$SessionVenueImpl(
+          id: $checkedConvert('id', (v) => v as String),
+          name: $checkedConvert('name', (v) => v as String),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$SessionVenueImplToJson(_$SessionVenueImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+    };

--- a/packages/common/data/lib/src/model/sns.dart
+++ b/packages/common/data/lib/src/model/sns.dart
@@ -14,16 +14,19 @@ enum SnsType {
   other,
   ;
 
-  String toUrl(String value) => switch (this) {
-        SnsType.github => 'https://github.com/$value',
-        SnsType.x => 'https://x.com/$value',
-        SnsType.discord => 'https://discord.com/users/$value',
-        SnsType.medium => 'https://medium.com/@$value',
-        SnsType.qiita => 'https://qiita.com/$value',
-        SnsType.zenn => 'https://zenn.dev/$value',
-        SnsType.note => 'https://note.com/$value',
-        SnsType.other => value,
-      };
+  Uri toUri(String value) {
+    final url = switch (this) {
+      SnsType.github => 'https://github.com/$value',
+      SnsType.x => 'https://x.com/$value',
+      SnsType.discord => 'https://discord.com/users/$value',
+      SnsType.medium => 'https://medium.com/@$value',
+      SnsType.qiita => 'https://qiita.com/$value',
+      SnsType.zenn => 'https://zenn.dev/$value',
+      SnsType.note => 'https://note.com/$value',
+      SnsType.other => value,
+    };
+    return Uri.parse(url);
+  }
 }
 
 @freezed

--- a/packages/common/data/lib/src/model/sns.dart
+++ b/packages/common/data/lib/src/model/sns.dart
@@ -1,6 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'sns.freezed.dart';
+part 'sns.g.dart';
 
 enum SnsType {
   github,
@@ -19,4 +20,7 @@ class SnsAccount with _$SnsAccount {
     required SnsType type,
     required Uri link,
   }) = _SnsAccount;
+
+  factory SnsAccount.fromJson(Map<String, dynamic> json) =>
+      _$SnsAccountFromJson(json);
 }

--- a/packages/common/data/lib/src/model/sns.dart
+++ b/packages/common/data/lib/src/model/sns.dart
@@ -12,6 +12,18 @@ enum SnsType {
   zenn,
   note,
   other,
+  ;
+
+  String toUrl(String value) => switch (this) {
+        SnsType.github => 'https://github.com/$value',
+        SnsType.x => 'https://x.com/$value',
+        SnsType.discord => 'https://discord.com/users/$value',
+        SnsType.medium => 'https://medium.com/@$value',
+        SnsType.qiita => 'https://qiita.com/$value',
+        SnsType.zenn => 'https://zenn.dev/$value',
+        SnsType.note => 'https://note.com/$value',
+        SnsType.other => value,
+      };
 }
 
 @freezed

--- a/packages/common/data/lib/src/model/sns.freezed.dart
+++ b/packages/common/data/lib/src/model/sns.freezed.dart
@@ -14,10 +14,17 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
+SnsAccount _$SnsAccountFromJson(Map<String, dynamic> json) {
+  return _SnsAccount.fromJson(json);
+}
+
 /// @nodoc
 mixin _$SnsAccount {
   SnsType get type => throw _privateConstructorUsedError;
   Uri get link => throw _privateConstructorUsedError;
+
+  /// Serializes this SnsAccount to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 
   /// Create a copy of SnsAccount
   /// with the given fields replaced by the non-null parameter values.
@@ -107,9 +114,12 @@ class __$$SnsAccountImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
+@JsonSerializable()
 class _$SnsAccountImpl implements _SnsAccount {
   const _$SnsAccountImpl({required this.type, required this.link});
+
+  factory _$SnsAccountImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SnsAccountImplFromJson(json);
 
   @override
   final SnsType type;
@@ -130,6 +140,7 @@ class _$SnsAccountImpl implements _SnsAccount {
             (identical(other.link, link) || other.link == link));
   }
 
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, type, link);
 
@@ -140,12 +151,22 @@ class _$SnsAccountImpl implements _SnsAccount {
   @pragma('vm:prefer-inline')
   _$$SnsAccountImplCopyWith<_$SnsAccountImpl> get copyWith =>
       __$$SnsAccountImplCopyWithImpl<_$SnsAccountImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SnsAccountImplToJson(
+      this,
+    );
+  }
 }
 
 abstract class _SnsAccount implements SnsAccount {
   const factory _SnsAccount(
       {required final SnsType type,
       required final Uri link}) = _$SnsAccountImpl;
+
+  factory _SnsAccount.fromJson(Map<String, dynamic> json) =
+      _$SnsAccountImpl.fromJson;
 
   @override
   SnsType get type;

--- a/packages/common/data/lib/src/model/sns.g.dart
+++ b/packages/common/data/lib/src/model/sns.g.dart
@@ -1,0 +1,40 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'sns.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SnsAccountImpl _$$SnsAccountImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$SnsAccountImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$SnsAccountImpl(
+          type:
+              $checkedConvert('type', (v) => $enumDecode(_$SnsTypeEnumMap, v)),
+          link: $checkedConvert('link', (v) => Uri.parse(v as String)),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$SnsAccountImplToJson(_$SnsAccountImpl instance) =>
+    <String, dynamic>{
+      'type': _$SnsTypeEnumMap[instance.type]!,
+      'link': instance.link.toString(),
+    };
+
+const _$SnsTypeEnumMap = {
+  SnsType.github: 'github',
+  SnsType.x: 'x',
+  SnsType.discord: 'discord',
+  SnsType.medium: 'medium',
+  SnsType.qiita: 'qiita',
+  SnsType.zenn: 'zenn',
+  SnsType.note: 'note',
+  SnsType.other: 'other',
+};

--- a/packages/common/data/lib/src/model/view/profile_with_sns.dart
+++ b/packages/common/data/lib/src/model/view/profile_with_sns.dart
@@ -1,4 +1,4 @@
-import 'package:common_data/staff.dart';
+import 'package:common_data/src/model/profile_social_networking_service.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'profile_with_sns.freezed.dart';
@@ -11,7 +11,7 @@ class ProfileWithSns with _$ProfileWithSns {
     required String name,
     required String avatarUrl,
     required String avatarName,
-    required List<SnsAccount> snsAccounts,
+    required List<ProfileSocialNetworkingService> snsAccounts,
   }) = _ProfileWithSns;
 
   factory ProfileWithSns.fromJson(Map<String, dynamic> json) =>

--- a/packages/common/data/lib/src/model/view/profile_with_sns.dart
+++ b/packages/common/data/lib/src/model/view/profile_with_sns.dart
@@ -1,0 +1,19 @@
+import 'package:common_data/staff.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'profile_with_sns.freezed.dart';
+part 'profile_with_sns.g.dart';
+
+@freezed
+class ProfileWithSns with _$ProfileWithSns {
+  const factory ProfileWithSns({
+    required String id,
+    required String name,
+    required String avatarUrl,
+    required String avatarName,
+    required List<SnsAccount> snsAccounts,
+  }) = _ProfileWithSns;
+
+  factory ProfileWithSns.fromJson(Map<String, dynamic> json) =>
+      _$ProfileWithSnsFromJson(json);
+}

--- a/packages/common/data/lib/src/model/view/profile_with_sns.freezed.dart
+++ b/packages/common/data/lib/src/model/view/profile_with_sns.freezed.dart
@@ -1,0 +1,259 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'profile_with_sns.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ProfileWithSns _$ProfileWithSnsFromJson(Map<String, dynamic> json) {
+  return _ProfileWithSns.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ProfileWithSns {
+  String get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  String get avatarUrl => throw _privateConstructorUsedError;
+  String get avatarName => throw _privateConstructorUsedError;
+  List<SnsAccount> get snsAccounts => throw _privateConstructorUsedError;
+
+  /// Serializes this ProfileWithSns to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ProfileWithSns
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ProfileWithSnsCopyWith<ProfileWithSns> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ProfileWithSnsCopyWith<$Res> {
+  factory $ProfileWithSnsCopyWith(
+          ProfileWithSns value, $Res Function(ProfileWithSns) then) =
+      _$ProfileWithSnsCopyWithImpl<$Res, ProfileWithSns>;
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      String avatarUrl,
+      String avatarName,
+      List<SnsAccount> snsAccounts});
+}
+
+/// @nodoc
+class _$ProfileWithSnsCopyWithImpl<$Res, $Val extends ProfileWithSns>
+    implements $ProfileWithSnsCopyWith<$Res> {
+  _$ProfileWithSnsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ProfileWithSns
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? avatarUrl = null,
+    Object? avatarName = null,
+    Object? snsAccounts = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      avatarUrl: null == avatarUrl
+          ? _value.avatarUrl
+          : avatarUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      avatarName: null == avatarName
+          ? _value.avatarName
+          : avatarName // ignore: cast_nullable_to_non_nullable
+              as String,
+      snsAccounts: null == snsAccounts
+          ? _value.snsAccounts
+          : snsAccounts // ignore: cast_nullable_to_non_nullable
+              as List<SnsAccount>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ProfileWithSnsImplCopyWith<$Res>
+    implements $ProfileWithSnsCopyWith<$Res> {
+  factory _$$ProfileWithSnsImplCopyWith(_$ProfileWithSnsImpl value,
+          $Res Function(_$ProfileWithSnsImpl) then) =
+      __$$ProfileWithSnsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String name,
+      String avatarUrl,
+      String avatarName,
+      List<SnsAccount> snsAccounts});
+}
+
+/// @nodoc
+class __$$ProfileWithSnsImplCopyWithImpl<$Res>
+    extends _$ProfileWithSnsCopyWithImpl<$Res, _$ProfileWithSnsImpl>
+    implements _$$ProfileWithSnsImplCopyWith<$Res> {
+  __$$ProfileWithSnsImplCopyWithImpl(
+      _$ProfileWithSnsImpl _value, $Res Function(_$ProfileWithSnsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ProfileWithSns
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? avatarUrl = null,
+    Object? avatarName = null,
+    Object? snsAccounts = null,
+  }) {
+    return _then(_$ProfileWithSnsImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      avatarUrl: null == avatarUrl
+          ? _value.avatarUrl
+          : avatarUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+      avatarName: null == avatarName
+          ? _value.avatarName
+          : avatarName // ignore: cast_nullable_to_non_nullable
+              as String,
+      snsAccounts: null == snsAccounts
+          ? _value._snsAccounts
+          : snsAccounts // ignore: cast_nullable_to_non_nullable
+              as List<SnsAccount>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ProfileWithSnsImpl implements _ProfileWithSns {
+  const _$ProfileWithSnsImpl(
+      {required this.id,
+      required this.name,
+      required this.avatarUrl,
+      required this.avatarName,
+      required final List<SnsAccount> snsAccounts})
+      : _snsAccounts = snsAccounts;
+
+  factory _$ProfileWithSnsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ProfileWithSnsImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String name;
+  @override
+  final String avatarUrl;
+  @override
+  final String avatarName;
+  final List<SnsAccount> _snsAccounts;
+  @override
+  List<SnsAccount> get snsAccounts {
+    if (_snsAccounts is EqualUnmodifiableListView) return _snsAccounts;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_snsAccounts);
+  }
+
+  @override
+  String toString() {
+    return 'ProfileWithSns(id: $id, name: $name, avatarUrl: $avatarUrl, avatarName: $avatarName, snsAccounts: $snsAccounts)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ProfileWithSnsImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.avatarUrl, avatarUrl) ||
+                other.avatarUrl == avatarUrl) &&
+            (identical(other.avatarName, avatarName) ||
+                other.avatarName == avatarName) &&
+            const DeepCollectionEquality()
+                .equals(other._snsAccounts, _snsAccounts));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name, avatarUrl, avatarName,
+      const DeepCollectionEquality().hash(_snsAccounts));
+
+  /// Create a copy of ProfileWithSns
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ProfileWithSnsImplCopyWith<_$ProfileWithSnsImpl> get copyWith =>
+      __$$ProfileWithSnsImplCopyWithImpl<_$ProfileWithSnsImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ProfileWithSnsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ProfileWithSns implements ProfileWithSns {
+  const factory _ProfileWithSns(
+      {required final String id,
+      required final String name,
+      required final String avatarUrl,
+      required final String avatarName,
+      required final List<SnsAccount> snsAccounts}) = _$ProfileWithSnsImpl;
+
+  factory _ProfileWithSns.fromJson(Map<String, dynamic> json) =
+      _$ProfileWithSnsImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get name;
+  @override
+  String get avatarUrl;
+  @override
+  String get avatarName;
+  @override
+  List<SnsAccount> get snsAccounts;
+
+  /// Create a copy of ProfileWithSns
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ProfileWithSnsImplCopyWith<_$ProfileWithSnsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/common/data/lib/src/model/view/profile_with_sns.freezed.dart
+++ b/packages/common/data/lib/src/model/view/profile_with_sns.freezed.dart
@@ -24,7 +24,8 @@ mixin _$ProfileWithSns {
   String get name => throw _privateConstructorUsedError;
   String get avatarUrl => throw _privateConstructorUsedError;
   String get avatarName => throw _privateConstructorUsedError;
-  List<SnsAccount> get snsAccounts => throw _privateConstructorUsedError;
+  List<ProfileSocialNetworkingService> get snsAccounts =>
+      throw _privateConstructorUsedError;
 
   /// Serializes this ProfileWithSns to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -47,7 +48,7 @@ abstract class $ProfileWithSnsCopyWith<$Res> {
       String name,
       String avatarUrl,
       String avatarName,
-      List<SnsAccount> snsAccounts});
+      List<ProfileSocialNetworkingService> snsAccounts});
 }
 
 /// @nodoc
@@ -91,7 +92,7 @@ class _$ProfileWithSnsCopyWithImpl<$Res, $Val extends ProfileWithSns>
       snsAccounts: null == snsAccounts
           ? _value.snsAccounts
           : snsAccounts // ignore: cast_nullable_to_non_nullable
-              as List<SnsAccount>,
+              as List<ProfileSocialNetworkingService>,
     ) as $Val);
   }
 }
@@ -109,7 +110,7 @@ abstract class _$$ProfileWithSnsImplCopyWith<$Res>
       String name,
       String avatarUrl,
       String avatarName,
-      List<SnsAccount> snsAccounts});
+      List<ProfileSocialNetworkingService> snsAccounts});
 }
 
 /// @nodoc
@@ -151,7 +152,7 @@ class __$$ProfileWithSnsImplCopyWithImpl<$Res>
       snsAccounts: null == snsAccounts
           ? _value._snsAccounts
           : snsAccounts // ignore: cast_nullable_to_non_nullable
-              as List<SnsAccount>,
+              as List<ProfileSocialNetworkingService>,
     ));
   }
 }
@@ -164,7 +165,7 @@ class _$ProfileWithSnsImpl implements _ProfileWithSns {
       required this.name,
       required this.avatarUrl,
       required this.avatarName,
-      required final List<SnsAccount> snsAccounts})
+      required final List<ProfileSocialNetworkingService> snsAccounts})
       : _snsAccounts = snsAccounts;
 
   factory _$ProfileWithSnsImpl.fromJson(Map<String, dynamic> json) =>
@@ -178,9 +179,9 @@ class _$ProfileWithSnsImpl implements _ProfileWithSns {
   final String avatarUrl;
   @override
   final String avatarName;
-  final List<SnsAccount> _snsAccounts;
+  final List<ProfileSocialNetworkingService> _snsAccounts;
   @override
-  List<SnsAccount> get snsAccounts {
+  List<ProfileSocialNetworkingService> get snsAccounts {
     if (_snsAccounts is EqualUnmodifiableListView) return _snsAccounts;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_snsAccounts);
@@ -230,11 +231,12 @@ class _$ProfileWithSnsImpl implements _ProfileWithSns {
 
 abstract class _ProfileWithSns implements ProfileWithSns {
   const factory _ProfileWithSns(
-      {required final String id,
-      required final String name,
-      required final String avatarUrl,
-      required final String avatarName,
-      required final List<SnsAccount> snsAccounts}) = _$ProfileWithSnsImpl;
+          {required final String id,
+          required final String name,
+          required final String avatarUrl,
+          required final String avatarName,
+          required final List<ProfileSocialNetworkingService> snsAccounts}) =
+      _$ProfileWithSnsImpl;
 
   factory _ProfileWithSns.fromJson(Map<String, dynamic> json) =
       _$ProfileWithSnsImpl.fromJson;
@@ -248,7 +250,7 @@ abstract class _ProfileWithSns implements ProfileWithSns {
   @override
   String get avatarName;
   @override
-  List<SnsAccount> get snsAccounts;
+  List<ProfileSocialNetworkingService> get snsAccounts;
 
   /// Create a copy of ProfileWithSns
   /// with the given fields replaced by the non-null parameter values.

--- a/packages/common/data/lib/src/model/view/profile_with_sns.g.dart
+++ b/packages/common/data/lib/src/model/view/profile_with_sns.g.dart
@@ -21,7 +21,8 @@ _$ProfileWithSnsImpl _$$ProfileWithSnsImplFromJson(Map<String, dynamic> json) =>
           snsAccounts: $checkedConvert(
               'sns_accounts',
               (v) => (v as List<dynamic>)
-                  .map((e) => SnsAccount.fromJson(e as Map<String, dynamic>))
+                  .map((e) => ProfileSocialNetworkingService.fromJson(
+                      e as Map<String, dynamic>))
                   .toList()),
         );
         return val;

--- a/packages/common/data/lib/src/model/view/profile_with_sns.g.dart
+++ b/packages/common/data/lib/src/model/view/profile_with_sns.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'profile_with_sns.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ProfileWithSnsImpl _$$ProfileWithSnsImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$ProfileWithSnsImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$ProfileWithSnsImpl(
+          id: $checkedConvert('id', (v) => v as String),
+          name: $checkedConvert('name', (v) => v as String),
+          avatarUrl: $checkedConvert('avatar_url', (v) => v as String),
+          avatarName: $checkedConvert('avatar_name', (v) => v as String),
+          snsAccounts: $checkedConvert(
+              'sns_accounts',
+              (v) => (v as List<dynamic>)
+                  .map((e) => SnsAccount.fromJson(e as Map<String, dynamic>))
+                  .toList()),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'avatarUrl': 'avatar_url',
+        'avatarName': 'avatar_name',
+        'snsAccounts': 'sns_accounts'
+      },
+    );
+
+Map<String, dynamic> _$$ProfileWithSnsImplToJson(
+        _$ProfileWithSnsImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'avatar_url': instance.avatarUrl,
+      'avatar_name': instance.avatarName,
+      'sns_accounts': instance.snsAccounts,
+    };

--- a/packages/common/data/lib/src/model/view/session_venues_with_sessions.dart
+++ b/packages/common/data/lib/src/model/view/session_venues_with_sessions.dart
@@ -1,0 +1,35 @@
+import 'package:common_data/src/model/sponsor.dart';
+import 'package:common_data/src/model/view/profile_with_sns.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'session_venues_with_sessions.freezed.dart';
+part 'session_venues_with_sessions.g.dart';
+
+@freezed
+class SessionVenuesWithSessions with _$SessionVenuesWithSessions {
+  const factory SessionVenuesWithSessions({
+    required String id,
+    required String name,
+
+  }) = _SessionVenuesWithSessions;
+
+  factory SessionVenuesWithSessions.fromJson(Map<String, dynamic> json) =>
+    _$SessionVenuesWithSessionsFromJson(json);
+}
+
+@freezed
+class SessionWithSpeakerAndSponsor with _$SessionWithSpeakerAndSponsor {
+  const factory SessionWithSpeakerAndSponsor({
+    required String id,
+    required String title,
+    required String description,
+    required DateTime startsAt,
+    required DateTime endsAt,
+    required bool isLightningTalk,
+    required List<ProfileWithSns> speakers,
+    required List<Sponsor> sponsors,
+  }) = _SessionWithSpeakerAndSponsor;
+
+  factory SessionWithSpeakerAndSponsor.fromJson(Map<String, dynamic> json) =>
+    _$SessionWithSpeakerAndSponsorFromJson(json);
+}

--- a/packages/common/data/lib/src/model/view/session_venues_with_sessions.freezed.dart
+++ b/packages/common/data/lib/src/model/view/session_venues_with_sessions.freezed.dart
@@ -1,0 +1,520 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'session_venues_with_sessions.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+SessionVenuesWithSessions _$SessionVenuesWithSessionsFromJson(
+    Map<String, dynamic> json) {
+  return _SessionVenuesWithSessions.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SessionVenuesWithSessions {
+  String get id => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+
+  /// Serializes this SessionVenuesWithSessions to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of SessionVenuesWithSessions
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SessionVenuesWithSessionsCopyWith<SessionVenuesWithSessions> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SessionVenuesWithSessionsCopyWith<$Res> {
+  factory $SessionVenuesWithSessionsCopyWith(SessionVenuesWithSessions value,
+          $Res Function(SessionVenuesWithSessions) then) =
+      _$SessionVenuesWithSessionsCopyWithImpl<$Res, SessionVenuesWithSessions>;
+  @useResult
+  $Res call({String id, String name});
+}
+
+/// @nodoc
+class _$SessionVenuesWithSessionsCopyWithImpl<$Res,
+        $Val extends SessionVenuesWithSessions>
+    implements $SessionVenuesWithSessionsCopyWith<$Res> {
+  _$SessionVenuesWithSessionsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SessionVenuesWithSessions
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SessionVenuesWithSessionsImplCopyWith<$Res>
+    implements $SessionVenuesWithSessionsCopyWith<$Res> {
+  factory _$$SessionVenuesWithSessionsImplCopyWith(
+          _$SessionVenuesWithSessionsImpl value,
+          $Res Function(_$SessionVenuesWithSessionsImpl) then) =
+      __$$SessionVenuesWithSessionsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String id, String name});
+}
+
+/// @nodoc
+class __$$SessionVenuesWithSessionsImplCopyWithImpl<$Res>
+    extends _$SessionVenuesWithSessionsCopyWithImpl<$Res,
+        _$SessionVenuesWithSessionsImpl>
+    implements _$$SessionVenuesWithSessionsImplCopyWith<$Res> {
+  __$$SessionVenuesWithSessionsImplCopyWithImpl(
+      _$SessionVenuesWithSessionsImpl _value,
+      $Res Function(_$SessionVenuesWithSessionsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SessionVenuesWithSessions
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+  }) {
+    return _then(_$SessionVenuesWithSessionsImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SessionVenuesWithSessionsImpl implements _SessionVenuesWithSessions {
+  const _$SessionVenuesWithSessionsImpl({required this.id, required this.name});
+
+  factory _$SessionVenuesWithSessionsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SessionVenuesWithSessionsImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String name;
+
+  @override
+  String toString() {
+    return 'SessionVenuesWithSessions(id: $id, name: $name)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SessionVenuesWithSessionsImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, name);
+
+  /// Create a copy of SessionVenuesWithSessions
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SessionVenuesWithSessionsImplCopyWith<_$SessionVenuesWithSessionsImpl>
+      get copyWith => __$$SessionVenuesWithSessionsImplCopyWithImpl<
+          _$SessionVenuesWithSessionsImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SessionVenuesWithSessionsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SessionVenuesWithSessions implements SessionVenuesWithSessions {
+  const factory _SessionVenuesWithSessions(
+      {required final String id,
+      required final String name}) = _$SessionVenuesWithSessionsImpl;
+
+  factory _SessionVenuesWithSessions.fromJson(Map<String, dynamic> json) =
+      _$SessionVenuesWithSessionsImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get name;
+
+  /// Create a copy of SessionVenuesWithSessions
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SessionVenuesWithSessionsImplCopyWith<_$SessionVenuesWithSessionsImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+SessionWithSpeakerAndSponsor _$SessionWithSpeakerAndSponsorFromJson(
+    Map<String, dynamic> json) {
+  return _SessionWithSpeakerAndSponsor.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SessionWithSpeakerAndSponsor {
+  String get id => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String get description => throw _privateConstructorUsedError;
+  DateTime get startsAt => throw _privateConstructorUsedError;
+  DateTime get endsAt => throw _privateConstructorUsedError;
+  bool get isLightningTalk => throw _privateConstructorUsedError;
+  List<ProfileWithSns> get speakers => throw _privateConstructorUsedError;
+  List<Sponsor> get sponsors => throw _privateConstructorUsedError;
+
+  /// Serializes this SessionWithSpeakerAndSponsor to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of SessionWithSpeakerAndSponsor
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SessionWithSpeakerAndSponsorCopyWith<SessionWithSpeakerAndSponsor>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SessionWithSpeakerAndSponsorCopyWith<$Res> {
+  factory $SessionWithSpeakerAndSponsorCopyWith(
+          SessionWithSpeakerAndSponsor value,
+          $Res Function(SessionWithSpeakerAndSponsor) then) =
+      _$SessionWithSpeakerAndSponsorCopyWithImpl<$Res,
+          SessionWithSpeakerAndSponsor>;
+  @useResult
+  $Res call(
+      {String id,
+      String title,
+      String description,
+      DateTime startsAt,
+      DateTime endsAt,
+      bool isLightningTalk,
+      List<ProfileWithSns> speakers,
+      List<Sponsor> sponsors});
+}
+
+/// @nodoc
+class _$SessionWithSpeakerAndSponsorCopyWithImpl<$Res,
+        $Val extends SessionWithSpeakerAndSponsor>
+    implements $SessionWithSpeakerAndSponsorCopyWith<$Res> {
+  _$SessionWithSpeakerAndSponsorCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SessionWithSpeakerAndSponsor
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? description = null,
+    Object? startsAt = null,
+    Object? endsAt = null,
+    Object? isLightningTalk = null,
+    Object? speakers = null,
+    Object? sponsors = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      startsAt: null == startsAt
+          ? _value.startsAt
+          : startsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      endsAt: null == endsAt
+          ? _value.endsAt
+          : endsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      isLightningTalk: null == isLightningTalk
+          ? _value.isLightningTalk
+          : isLightningTalk // ignore: cast_nullable_to_non_nullable
+              as bool,
+      speakers: null == speakers
+          ? _value.speakers
+          : speakers // ignore: cast_nullable_to_non_nullable
+              as List<ProfileWithSns>,
+      sponsors: null == sponsors
+          ? _value.sponsors
+          : sponsors // ignore: cast_nullable_to_non_nullable
+              as List<Sponsor>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$SessionWithSpeakerAndSponsorImplCopyWith<$Res>
+    implements $SessionWithSpeakerAndSponsorCopyWith<$Res> {
+  factory _$$SessionWithSpeakerAndSponsorImplCopyWith(
+          _$SessionWithSpeakerAndSponsorImpl value,
+          $Res Function(_$SessionWithSpeakerAndSponsorImpl) then) =
+      __$$SessionWithSpeakerAndSponsorImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String title,
+      String description,
+      DateTime startsAt,
+      DateTime endsAt,
+      bool isLightningTalk,
+      List<ProfileWithSns> speakers,
+      List<Sponsor> sponsors});
+}
+
+/// @nodoc
+class __$$SessionWithSpeakerAndSponsorImplCopyWithImpl<$Res>
+    extends _$SessionWithSpeakerAndSponsorCopyWithImpl<$Res,
+        _$SessionWithSpeakerAndSponsorImpl>
+    implements _$$SessionWithSpeakerAndSponsorImplCopyWith<$Res> {
+  __$$SessionWithSpeakerAndSponsorImplCopyWithImpl(
+      _$SessionWithSpeakerAndSponsorImpl _value,
+      $Res Function(_$SessionWithSpeakerAndSponsorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SessionWithSpeakerAndSponsor
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? title = null,
+    Object? description = null,
+    Object? startsAt = null,
+    Object? endsAt = null,
+    Object? isLightningTalk = null,
+    Object? speakers = null,
+    Object? sponsors = null,
+  }) {
+    return _then(_$SessionWithSpeakerAndSponsorImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      title: null == title
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      startsAt: null == startsAt
+          ? _value.startsAt
+          : startsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      endsAt: null == endsAt
+          ? _value.endsAt
+          : endsAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      isLightningTalk: null == isLightningTalk
+          ? _value.isLightningTalk
+          : isLightningTalk // ignore: cast_nullable_to_non_nullable
+              as bool,
+      speakers: null == speakers
+          ? _value._speakers
+          : speakers // ignore: cast_nullable_to_non_nullable
+              as List<ProfileWithSns>,
+      sponsors: null == sponsors
+          ? _value._sponsors
+          : sponsors // ignore: cast_nullable_to_non_nullable
+              as List<Sponsor>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SessionWithSpeakerAndSponsorImpl
+    implements _SessionWithSpeakerAndSponsor {
+  const _$SessionWithSpeakerAndSponsorImpl(
+      {required this.id,
+      required this.title,
+      required this.description,
+      required this.startsAt,
+      required this.endsAt,
+      required this.isLightningTalk,
+      required final List<ProfileWithSns> speakers,
+      required final List<Sponsor> sponsors})
+      : _speakers = speakers,
+        _sponsors = sponsors;
+
+  factory _$SessionWithSpeakerAndSponsorImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$SessionWithSpeakerAndSponsorImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String title;
+  @override
+  final String description;
+  @override
+  final DateTime startsAt;
+  @override
+  final DateTime endsAt;
+  @override
+  final bool isLightningTalk;
+  final List<ProfileWithSns> _speakers;
+  @override
+  List<ProfileWithSns> get speakers {
+    if (_speakers is EqualUnmodifiableListView) return _speakers;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_speakers);
+  }
+
+  final List<Sponsor> _sponsors;
+  @override
+  List<Sponsor> get sponsors {
+    if (_sponsors is EqualUnmodifiableListView) return _sponsors;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sponsors);
+  }
+
+  @override
+  String toString() {
+    return 'SessionWithSpeakerAndSponsor(id: $id, title: $title, description: $description, startsAt: $startsAt, endsAt: $endsAt, isLightningTalk: $isLightningTalk, speakers: $speakers, sponsors: $sponsors)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SessionWithSpeakerAndSponsorImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.startsAt, startsAt) ||
+                other.startsAt == startsAt) &&
+            (identical(other.endsAt, endsAt) || other.endsAt == endsAt) &&
+            (identical(other.isLightningTalk, isLightningTalk) ||
+                other.isLightningTalk == isLightningTalk) &&
+            const DeepCollectionEquality().equals(other._speakers, _speakers) &&
+            const DeepCollectionEquality().equals(other._sponsors, _sponsors));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      title,
+      description,
+      startsAt,
+      endsAt,
+      isLightningTalk,
+      const DeepCollectionEquality().hash(_speakers),
+      const DeepCollectionEquality().hash(_sponsors));
+
+  /// Create a copy of SessionWithSpeakerAndSponsor
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SessionWithSpeakerAndSponsorImplCopyWith<
+          _$SessionWithSpeakerAndSponsorImpl>
+      get copyWith => __$$SessionWithSpeakerAndSponsorImplCopyWithImpl<
+          _$SessionWithSpeakerAndSponsorImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SessionWithSpeakerAndSponsorImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SessionWithSpeakerAndSponsor
+    implements SessionWithSpeakerAndSponsor {
+  const factory _SessionWithSpeakerAndSponsor(
+          {required final String id,
+          required final String title,
+          required final String description,
+          required final DateTime startsAt,
+          required final DateTime endsAt,
+          required final bool isLightningTalk,
+          required final List<ProfileWithSns> speakers,
+          required final List<Sponsor> sponsors}) =
+      _$SessionWithSpeakerAndSponsorImpl;
+
+  factory _SessionWithSpeakerAndSponsor.fromJson(Map<String, dynamic> json) =
+      _$SessionWithSpeakerAndSponsorImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get title;
+  @override
+  String get description;
+  @override
+  DateTime get startsAt;
+  @override
+  DateTime get endsAt;
+  @override
+  bool get isLightningTalk;
+  @override
+  List<ProfileWithSns> get speakers;
+  @override
+  List<Sponsor> get sponsors;
+
+  /// Create a copy of SessionWithSpeakerAndSponsor
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SessionWithSpeakerAndSponsorImplCopyWith<
+          _$SessionWithSpeakerAndSponsorImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/common/data/lib/src/model/view/session_venues_with_sessions.g.dart
+++ b/packages/common/data/lib/src/model/view/session_venues_with_sessions.g.dart
@@ -1,0 +1,80 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'session_venues_with_sessions.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$SessionVenuesWithSessionsImpl _$$SessionVenuesWithSessionsImplFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$SessionVenuesWithSessionsImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$SessionVenuesWithSessionsImpl(
+          id: $checkedConvert('id', (v) => v as String),
+          name: $checkedConvert('name', (v) => v as String),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$SessionVenuesWithSessionsImplToJson(
+        _$SessionVenuesWithSessionsImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+    };
+
+_$SessionWithSpeakerAndSponsorImpl _$$SessionWithSpeakerAndSponsorImplFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$SessionWithSpeakerAndSponsorImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$SessionWithSpeakerAndSponsorImpl(
+          id: $checkedConvert('id', (v) => v as String),
+          title: $checkedConvert('title', (v) => v as String),
+          description: $checkedConvert('description', (v) => v as String),
+          startsAt:
+              $checkedConvert('starts_at', (v) => DateTime.parse(v as String)),
+          endsAt:
+              $checkedConvert('ends_at', (v) => DateTime.parse(v as String)),
+          isLightningTalk:
+              $checkedConvert('is_lightning_talk', (v) => v as bool),
+          speakers: $checkedConvert(
+              'speakers',
+              (v) => (v as List<dynamic>)
+                  .map(
+                      (e) => ProfileWithSns.fromJson(e as Map<String, dynamic>))
+                  .toList()),
+          sponsors: $checkedConvert(
+              'sponsors',
+              (v) => (v as List<dynamic>)
+                  .map((e) => Sponsor.fromJson(e as Map<String, dynamic>))
+                  .toList()),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'startsAt': 'starts_at',
+        'endsAt': 'ends_at',
+        'isLightningTalk': 'is_lightning_talk'
+      },
+    );
+
+Map<String, dynamic> _$$SessionWithSpeakerAndSponsorImplToJson(
+        _$SessionWithSpeakerAndSponsorImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'description': instance.description,
+      'starts_at': instance.startsAt.toIso8601String(),
+      'ends_at': instance.endsAt.toIso8601String(),
+      'is_lightning_talk': instance.isLightningTalk,
+      'speakers': instance.speakers,
+      'sponsors': instance.sponsors,
+    };

--- a/packages/common/data/lib/src/repository/session_repository.dart
+++ b/packages/common/data/lib/src/repository/session_repository.dart
@@ -28,7 +28,7 @@ class SessionRepository {
 
   final SupabaseClient _client;
 
-  Future<List<Session>> getSessions() async =>
+  Future<List<Session>> fetchSessions() async =>
       _client.from('sessions').select().withConverter(
             (data) => data.map(Session.fromJson).toList(),
           );
@@ -68,7 +68,7 @@ class SessionVenueRepository {
 
   final SupabaseClient _client;
 
-  Future<List<SessionVenue>> getSessionVenues() async =>
+  Future<List<SessionVenue>> fetchSessionVenues() async =>
       _client.from('session_venues').select().withConverter(
             (data) => data.map(SessionVenue.fromJson).toList(),
           );
@@ -101,7 +101,7 @@ class SessionSpeakerRepository {
 
   final SupabaseClient _client;
 
-  Future<List<SessionSpeaker>> getSessionSpeakers() async =>
+  Future<List<SessionSpeaker>> fetchSessionSpeakers() async =>
       _client.from('session_speakers').select().withConverter(
             (data) => data.map(SessionSpeaker.fromJson).toList(),
           );

--- a/packages/common/data/lib/src/repository/session_repository.dart
+++ b/packages/common/data/lib/src/repository/session_repository.dart
@@ -1,15 +1,129 @@
+import 'package:common_data/src/model/session.dart';
+import 'package:common_data/src/model/session_speaker.dart';
+import 'package:common_data/src/model/session_venue.dart';
 import 'package:common_data/src/supabase_client.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' hide Session;
 
 part 'session_repository.g.dart';
 
 @Riverpod(keepAlive: true)
-SessionRepository sessionRepository(SessionRepositoryRef ref)
-=> SessionRepository(client: ref.watch(supabaseClientProvider));
+SessionRepository sessionRepository(SessionRepositoryRef ref) =>
+    SessionRepository(client: ref.watch(supabaseClientProvider));
+
+@Riverpod(keepAlive: true)
+SessionVenueRepository sessionVenueRepository(SessionVenueRepositoryRef ref) =>
+    SessionVenueRepository(client: ref.watch(supabaseClientProvider));
+
+@Riverpod(keepAlive: true)
+SessionSpeakerRepository sessionSpeakerRepository(
+  SessionSpeakerRepositoryRef ref,
+) =>
+    SessionSpeakerRepository(client: ref.watch(supabaseClientProvider));
 
 class SessionRepository {
-  SessionRepository({required SupabaseClient client,}) : _client = client;
+  SessionRepository({
+    required SupabaseClient client,
+  }) : _client = client;
 
   final SupabaseClient _client;
+
+  Future<List<Session>> getSessions() async =>
+      _client.from('sessions').select().withConverter(
+            (data) => data.map(Session.fromJson).toList(),
+          );
+
+  Future<Session> createSession({
+    required String title,
+    required String description,
+    required DateTime startsAt,
+    required DateTime endsAt,
+    required String? venueId,
+    required int? sponsorId,
+    required bool isLightningTalk,
+  }) async =>
+      _client
+          .from('sessions')
+          .insert({
+            'title': title,
+            'description': description,
+            'starts_at': startsAt,
+            'ends_at': endsAt,
+            'venue_id': venueId,
+            'sponsor_id': sponsorId,
+            'is_lightning_talk': isLightningTalk,
+          })
+          .select()
+          .single()
+          .withConverter(Session.fromJson);
+
+  Future<void> deleteSession(String id) async =>
+      _client.from('sessions').delete().eq('id', id);
+}
+
+class SessionVenueRepository {
+  SessionVenueRepository({
+    required SupabaseClient client,
+  }) : _client = client;
+
+  final SupabaseClient _client;
+
+  Future<List<SessionVenue>> getSessionVenues() async =>
+      _client.from('session_venues').select().withConverter(
+            (data) => data.map(SessionVenue.fromJson).toList(),
+          );
+
+  Future<SessionVenue> createSessionVenue({
+    required String name,
+  }) async =>
+      _client
+          .from('session_venues')
+          .insert({
+            'name': name,
+          })
+          .select()
+          .single()
+          .withConverter(SessionVenue.fromJson);
+
+  Future<void> deleteSessionVenue(String id) async =>
+      _client.from('session_venues').delete().eq('id', id);
+
+  Future<void> updateSessionVenue(String id, {required String name}) async =>
+      _client.from('session_venues').update({
+        'name': name,
+      }).eq('id', id);
+}
+
+class SessionSpeakerRepository {
+  SessionSpeakerRepository({
+    required SupabaseClient client,
+  }) : _client = client;
+
+  final SupabaseClient _client;
+
+  Future<List<SessionSpeaker>> getSessionSpeakers() async =>
+      _client.from('session_speakers').select().withConverter(
+            (data) => data.map(SessionSpeaker.fromJson).toList(),
+          );
+
+  Future<SessionSpeaker> createSessionSpeaker({
+    required String sessionId,
+    required String speakerId,
+  }) async =>
+      _client
+          .from('session_speakers')
+          .insert({
+            'session_id': sessionId,
+            'speaker_id': speakerId,
+          })
+          .select()
+          .single()
+          .withConverter(SessionSpeaker.fromJson);
+
+  Future<void> deleteSessionSpeaker(String sessionId, String speakerId) async =>
+      _client
+          .from('session_speakers')
+          .delete()
+          .eq('session_id', sessionId)
+          .eq('speaker_id', speakerId);
 }

--- a/packages/common/data/lib/src/repository/session_repository.dart
+++ b/packages/common/data/lib/src/repository/session_repository.dart
@@ -1,6 +1,7 @@
 import 'package:common_data/src/model/session.dart';
 import 'package:common_data/src/model/session_speaker.dart';
 import 'package:common_data/src/model/session_venue.dart';
+import 'package:common_data/src/model/view/session_venues_with_sessions.dart';
 import 'package:common_data/src/supabase_client.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' hide Session;
@@ -27,6 +28,12 @@ class SessionRepository {
   }) : _client = client;
 
   final SupabaseClient _client;
+
+  Future<List<SessionVenuesWithSessions>>
+      fetchSessionVenuesWithSessions() async =>
+          _client.from('session_venues_with_sessions').select().withConverter(
+                (list) => list.map(SessionVenuesWithSessions.fromJson).toList(),
+              );
 
   Future<List<Session>> fetchSessions() async =>
       _client.from('sessions').select().withConverter(

--- a/packages/common/data/lib/src/repository/session_repository.dart
+++ b/packages/common/data/lib/src/repository/session_repository.dart
@@ -1,0 +1,15 @@
+import 'package:common_data/src/supabase_client.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'session_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+SessionRepository sessionRepository(SessionRepositoryRef ref)
+=> SessionRepository(client: ref.watch(supabaseClientProvider));
+
+class SessionRepository {
+  SessionRepository({required SupabaseClient client,}) : _client = client;
+
+  final SupabaseClient _client;
+}

--- a/packages/common/data/lib/src/repository/session_repository.g.dart
+++ b/packages/common/data/lib/src/repository/session_repository.g.dart
@@ -23,5 +23,39 @@ final sessionRepositoryProvider = Provider<SessionRepository>.internal(
 );
 
 typedef SessionRepositoryRef = ProviderRef<SessionRepository>;
+String _$sessionVenueRepositoryHash() =>
+    r'3497b6a0fcadf2a076d1db8cd77bc2b13ea839dd';
+
+/// See also [sessionVenueRepository].
+@ProviderFor(sessionVenueRepository)
+final sessionVenueRepositoryProvider =
+    Provider<SessionVenueRepository>.internal(
+  sessionVenueRepository,
+  name: r'sessionVenueRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$sessionVenueRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef SessionVenueRepositoryRef = ProviderRef<SessionVenueRepository>;
+String _$sessionSpeakerRepositoryHash() =>
+    r'14966bf7b3105c909f9b751b3aa38f57754431a0';
+
+/// See also [sessionSpeakerRepository].
+@ProviderFor(sessionSpeakerRepository)
+final sessionSpeakerRepositoryProvider =
+    Provider<SessionSpeakerRepository>.internal(
+  sessionSpeakerRepository,
+  name: r'sessionSpeakerRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$sessionSpeakerRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef SessionSpeakerRepositoryRef = ProviderRef<SessionSpeakerRepository>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/packages/common/data/lib/src/repository/session_repository.g.dart
+++ b/packages/common/data/lib/src/repository/session_repository.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'session_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$sessionRepositoryHash() => r'd0510285675e28ec8268f8efa728c71608c6e9c1';
+
+/// See also [sessionRepository].
+@ProviderFor(sessionRepository)
+final sessionRepositoryProvider = Provider<SessionRepository>.internal(
+  sessionRepository,
+  name: r'sessionRepositoryProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$sessionRepositoryHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef SessionRepositoryRef = ProviderRef<SessionRepository>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/packages/common/data/lib/src/repository/staff_repository.dart
+++ b/packages/common/data/lib/src/repository/staff_repository.dart
@@ -38,8 +38,7 @@ final class StaffRepository {
       final snsAccounts = staffView.snsAccounts.map((snsAccount) {
         final snsType = SnsType.values.byName(snsAccount.type);
         final snsValue = snsAccount.value;
-        final linkText = snsType.toUrl(snsValue);
-        final link = Uri.parse(linkText);
+        final link = snsType.toUri(snsValue);
         return SnsAccount(
           type: snsType,
           link: link,

--- a/packages/common/data/lib/src/repository/staff_repository.dart
+++ b/packages/common/data/lib/src/repository/staff_repository.dart
@@ -38,16 +38,7 @@ final class StaffRepository {
       final snsAccounts = staffView.snsAccounts.map((snsAccount) {
         final snsType = SnsType.values.byName(snsAccount.type);
         final snsValue = snsAccount.value;
-        final linkText = switch (snsType) {
-          SnsType.github => 'https://github.com/$snsValue',
-          SnsType.x => 'https://x.com/$snsValue',
-          SnsType.discord => 'https://discord.com/users/$snsValue',
-          SnsType.medium => 'https://medium.com/@$snsValue',
-          SnsType.qiita => 'https://qiita.com/$snsValue',
-          SnsType.zenn => 'https://zenn.dev/$snsValue',
-          SnsType.note => 'https://note.com/$snsValue',
-          SnsType.other => snsValue,
-        };
+        final linkText = snsType.toUrl(snsValue);
         final link = Uri.parse(linkText);
         return SnsAccount(
           type: snsType,

--- a/packages/common/data/supabase/migrations/20240921100801_add_session_table.sql
+++ b/packages/common/data/supabase/migrations/20240921100801_add_session_table.sql
@@ -14,7 +14,8 @@ CREATE TABLE public.sessions (
   starts_at TIMESTAMP WITH TIME ZONE NOT NULL,
   ends_at TIMESTAMP WITH TIME ZONE NOT NULL,
   venue_id UUID NOT NULL REFERENCES session_venues (id) ON DELETE restrict,
-  sponsor_id smallint REFERENCES sponsors (id),
+  sponsor_id smallint REFERENCES sponsors (id), -- `sponsor_id`が値を持つ時、そのセッションはスポンサーセッションとして扱う
+  is_lightning_talk BOOLEAN NOT NULL DEFAULT FALSE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL
 );
 
@@ -80,6 +81,8 @@ SELECT
       s.starts_at,
       'ends_at',
       s.ends_at,
+      'is_lightning_talk',
+      s.is_lightning_talk,
       'speakers',
       (
         SELECT

--- a/packages/common/data/supabase/util/add_sample_sessions.sql
+++ b/packages/common/data/supabase/util/add_sample_sessions.sql
@@ -23,6 +23,7 @@ DECLARE
   session_id UUID;
   sponsor_id INT;
   i INT;
+  is_lightning_talk BOOLEAN;
 BEGIN
   FOR i IN 1..500 LOOP
     -- ランダムな会場を選択
@@ -35,15 +36,23 @@ BEGIN
       sponsor_id := NULL;
     END IF;
 
+    -- 30%の確率でライトニングトークとして扱う
+    IF RANDOM() < 0.3 THEN
+      is_lightning_talk := TRUE;
+    ELSE
+      is_lightning_talk := FALSE;
+    END IF;
+
     -- セッションを挿入
-    INSERT INTO public.sessions (title, description, starts_at, ends_at, venue_id, sponsor_id)
+    INSERT INTO public.sessions (title, description, starts_at, ends_at, venue_id, sponsor_id, is_lightning_talk)
     VALUES (
       'サンプルセッション ' || i,
       'これはサンプルセッション ' || i || ' の説明です。',
       NOW() + (RANDOM() * INTERVAL '7 days'),
       NOW() + (RANDOM() * INTERVAL '7 days') + INTERVAL '1 hour',
       venue_id,
-      sponsor_id
+      sponsor_id,
+      is_lightning_talk
     ) RETURNING id INTO session_id;
 
     -- ランダムな登壇者を1-3人選択


### PR DESCRIPTION
> [!WARNING]
> - #235 をマージしてから本PRをマージしてください

## 説明

- 各種テーブル・VIEWに対するRepositoryを作成しました
  - `SessionRepository`: `public.sessions`テーブルに対するCRUD処理・`public.session_venues_with_sessions` Viewに対するSELECT処理を管理
  - `SessionVenueRepository`: `public.session_venue`テーブルに対するCRUD処理
  - `SessionSpeakerRepository`: `public.session_speaker`テーブルに対するCRUD処理

## メモ
- SELECT処理だけではなく、Create, Update, Delete処理も実装しているのは `admin`権限をもつユーザ(=FlutterKaigiの一部メンバー)がそういった処理をできるようにするためです
  - UIを実装できるかどうかわかりませんが一応作成しておきました
  - 一般ユーザはRLSに弾かれます