### PR TITLE
[ticket] (api) プロモーションコード周りのAPIを作成

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,9 +6,11 @@
     "generate:supabase": "supabase gen types typescript -s public,stripe --project-id=xflwrlgfukzpgkudzrlu > src/util/supabaseSchema.ts"
   },
   "dependencies": {
+    "@hono-rate-limiter/cloudflare": "^0.2.1",
     "@hono/valibot-validator": "^0.3.0",
     "@supabase/supabase-js": "^2.45.4",
     "hono": "^4.6.2",
+    "hono-rate-limiter": "^0.4.0",
     "stripe": "^16.12.0",
     "valibot": "^0.41.0"
   },

--- a/api/pnpm-lock.yaml
+++ b/api/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hono-rate-limiter/cloudflare':
+        specifier: ^0.2.1
+        version: 0.2.1(@cloudflare/workers-types@4.20240919.0)(hono@4.6.2)
       '@hono/valibot-validator':
         specifier: ^0.3.0
         version: 0.3.0(hono@4.6.2)(valibot@0.41.0)
@@ -17,6 +20,9 @@ importers:
       hono:
         specifier: ^4.6.2
         version: 4.6.2
+      hono-rate-limiter:
+        specifier: ^0.4.0
+        version: 0.4.0(hono@4.6.2)
       stripe:
         specifier: ^16.12.0
         version: 16.12.0
@@ -224,6 +230,12 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
+  '@hono-rate-limiter/cloudflare@0.2.1':
+    resolution: {integrity: sha512-Ax0xHm3Q9V0dJ8nfdAZOm34tT9uoF+GY4qFXSiNliLb78wMhRp9wg0v7YlQYPSXMNu8aoEmdCwx2LpQw8iVDMA==}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20240529.0
+      hono: ^4.4.8
+
   '@hono/valibot-validator@0.3.0':
     resolution: {integrity: sha512-EcGJKzLt11SK4K11yKHrhI93ECtKeSHAnnENHw5tCL0ZhyDIx96avc3Ua8/ri4fwVvRPuOzFQ2OBRsVvwZuqeQ==}
     peerDependencies:
@@ -405,6 +417,11 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hono-rate-limiter@0.4.0:
+    resolution: {integrity: sha512-7RWU2HZvxPtfBrvjXKDiQ3F6ZH8k49JhxVkHquUz5UZKjauj5PrP29MvISykThtfpy4mGG6kqxFBHW1ed9wwnA==}
+    peerDependencies:
+      hono: ^4.1.1
 
   hono@4.6.2:
     resolution: {integrity: sha512-v+39817TgAhetmHUEli8O0uHDmxp2Up3DnhS4oUZXOl5IQ9np9tYtldd42e5zgdLVS0wsOoXQNZ6mx+BGmEvCA==}
@@ -730,6 +747,11 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
+  '@hono-rate-limiter/cloudflare@0.2.1(@cloudflare/workers-types@4.20240919.0)(hono@4.6.2)':
+    dependencies:
+      '@cloudflare/workers-types': 4.20240919.0
+      hono: 4.6.2
+
   '@hono/valibot-validator@0.3.0(hono@4.6.2)(valibot@0.41.0)':
     dependencies:
       hono: 4.6.2
@@ -948,6 +970,10 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hono-rate-limiter@0.4.0(hono@4.6.2):
+    dependencies:
+      hono: 4.6.2
 
   hono@4.6.2: {}
 

--- a/api/src/bindings.d.ts
+++ b/api/src/bindings.d.ts
@@ -2,4 +2,5 @@ export type Bindings = {
   SUPABASE_URL: string;
   SUPABASE_KEY: string;
   STRIPE_KEY: string;
+  RATE_LIMITER: KVNamespace;
 };

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,7 +2,7 @@ import { logger } from "hono/logger";
 import { cors } from "hono/cors";
 import { secureHeaders } from "hono/secure-headers";
 import { prettyJSON } from "hono/pretty-json";
-import {  Hono } from "hono";
+import { Hono } from "hono";
 import { Bindings } from "./bindings";
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,15 +2,13 @@ import { logger } from "hono/logger";
 import { cors } from "hono/cors";
 import { secureHeaders } from "hono/secure-headers";
 import { prettyJSON } from "hono/pretty-json";
-import { Hono } from "hono";
+import {  Hono } from "hono";
 import { Bindings } from "./bindings";
 import { HTTPException } from "hono/http-exception";
 import * as v from "valibot";
 
 import v1 from "./routes/v1/v1";
 import Stripe from "stripe";
-import { WorkersKVStore } from "@hono-rate-limiter/cloudflare";
-import { rateLimiter } from "hono-rate-limiter";
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -23,20 +21,6 @@ app.use(
 app.use(logger());
 app.use(secureHeaders());
 app.use(prettyJSON());
-
-export function limiter(kv: KVNamespace) {
-  return rateLimiter<{ Bindings: Bindings }>({
-    windowMs: 1 * 60 * 1000, // 1 minute
-    limit: 10, // 1分間に10回まで
-    standardHeaders: "draft-7",
-    keyGenerator: (c) => c.req.header("cf-connecting-ip") ?? "",
-    store: new WorkersKVStore({ namespace: kv }),
-    skipSuccessfulRequests: true,
-    message: (c) => {
-      return "Too many requests. Please try again after 1 minute.";
-    }
-  });
-}
 
 app.onError((err, c) => {
   if (err instanceof HTTPException) {

--- a/api/src/middleware/rateLimiter.ts
+++ b/api/src/middleware/rateLimiter.ts
@@ -1,0 +1,17 @@
+import { Bindings } from "../bindings";
+import { WorkersKVStore } from "@hono-rate-limiter/cloudflare";
+import { rateLimiter as rateLimiterMiddleware } from "hono-rate-limiter";
+
+export function rateLimiter(kv: KVNamespace) {
+  return rateLimiterMiddleware<{ Bindings: Bindings }>({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    limit: 10, // 1分間に10回まで
+    standardHeaders: "draft-7",
+    keyGenerator: (c) => c.req.header("cf-connecting-ip") ?? "",
+    store: new WorkersKVStore({ namespace: kv }),
+    skipSuccessfulRequests: true,
+    message: (c) => {
+      return "Too many requests. Please try again after 1 minute.";
+    }
+  });
+}

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -4,3 +4,7 @@ compatibility_date = "2024-09-05"
 main = "./src/index.ts"
 
 placement = { mode = "smart" }
+
+[[kv_namespaces]]
+binding = "RATE_LIMITER"
+id = "36ed2056500d4c4ba321baca10c4c95b"


### PR DESCRIPTION
> [!WARNING]
> - 以下PRをマージしてから本PRをマージしてください
>   - #235 
>   - #237 
>   - #240
>   - #241
>   - #242 
>   - #243 
>   - #245
>   - #246 
>   - #247 
>   - #250 
>   - #252 
>   - #253 
>   - #255
> - PRの宛先を`main`ブランチに変更すること 
## 説明
- プロモーションコード周りのエンドポイントを作成しました
  - **`PUT /v1/promotion`**: JSON Bodyの`metadata`, `maxRedemptions`に従った100%のプロモーションコードを発行します (要ログイン・`role() = admin`を要求)  
  - **`GET /v1/promotion`**: クエリパラメータ`code`にマッチするプロモーションコードがあるかどうかを検証します
    - ある場合は、metadataを返します
    - ない場合は、404 Not Foundになります
    - 本エンドポイントは、ランダムな値で検証を行い プロモーションコードを探そうとする行為を防ぐため レート制限の対象にしています
      - 1分間に10回まで叩けます
        - `PUT /v1/promotion`によって生成されるプロモーションコードは 2文字+6文字で成り立っていて 2文字部分は4種類・6文字部分は[0-9, a-f]の`16^6`の複雑性。
        - $4 \times 16^6 =　6,7108,864$　より、1分に10回試行すると 4660日で全探索できる計算になる。
        - 多分十分。。。
        - (`PUT /v1/promotion`エンドポイント以外でもプロモーションコードが生成され、かつ推測可能な文字列だった場合 現実的な時間内でプロモーションコードを見つけられます。)