### PR TITLE
[website] yet_another_json_isolate, vector_graphicsを修正版にoverride

### DIFF
--- a/apps/app/pubspec.lock
+++ b/apps/app/pubspec.lock
@@ -418,10 +418,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "2ddb88e9ad56ae15ee144ed10e33886777eb5ca2509a914850a5faa7b52ff459"
+      sha256: "5cf5fdcf853b0629deb35891c7af643be900c3dcaed7489009f9e7dbcfe55ab6"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.7"
+    version: "14.2.8"
   go_router_builder:
     dependency: "direct dev"
     description:
@@ -1082,10 +1082,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1114,10 +1114,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: f33d6bb662f0e4f79dcd7ada2e6170f3b3a2530c28fc41f49a411ddedd576a77
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.5.1"
   vector_graphics:
     dependency: transitive
     description:
@@ -1170,10 +1170,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   web_socket:
     dependency: transitive
     description:

--- a/apps/ticket_web/pubspec.lock
+++ b/apps/ticket_web/pubspec.lock
@@ -1250,8 +1250,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/vector_graphics"
-      ref: "8f7abd11cff39096b829e3810f7eb12474bc8e58"
-      resolved-ref: "8f7abd11cff39096b829e3810f7eb12474bc8e58"
+      ref: ae04010d19feff0db4e5b1763aa43d340fa6fa5e
+      resolved-ref: ae04010d19feff0db4e5b1763aa43d340fa6fa5e
       url: "https://github.com/YumNumm/vector_graphics.git"
     source: git
     version: "1.1.11+1"

--- a/apps/ticket_web/pubspec.lock
+++ b/apps/ticket_web/pubspec.lock
@@ -1249,10 +1249,11 @@ packages:
   vector_graphics:
     dependency: "direct main"
     description:
-      name: vector_graphics
-      sha256: "32c3c684e02f9bc0afb0ae0aa653337a2fe022e8ab064bcd7ffda27a74e288e3"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/vector_graphics"
+      ref: "8f7abd11cff39096b829e3810f7eb12474bc8e58"
+      resolved-ref: "8f7abd11cff39096b829e3810f7eb12474bc8e58"
+      url: "https://github.com/YumNumm/vector_graphics.git"
+    source: git
     version: "1.1.11+1"
   vector_graphics_codec:
     dependency: transitive

--- a/apps/ticket_web/pubspec.lock
+++ b/apps/ticket_web/pubspec.lock
@@ -1351,12 +1351,13 @@ packages:
     source: hosted
     version: "3.1.2"
   yet_another_json_isolate:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: yet_another_json_isolate
-      sha256: "47ed3900e6b0e4dfe378811a4402e85b7fc126a7daa94f840fef65ea9c8e46f4"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/yet_another_json_isolate"
+      ref: "4edc00b3b70621d37814b8c1fbef448655a4b222"
+      resolved-ref: "4edc00b3b70621d37814b8c1fbef448655a4b222"
+      url: "https://github.com/YumNumm/supabase-flutter.git"
+    source: git
     version: "2.0.2"
 sdks:
   dart: ">=3.6.0-216.1.beta <4.0.0"

--- a/apps/ticket_web/pubspec.lock
+++ b/apps/ticket_web/pubspec.lock
@@ -437,10 +437,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "2ddb88e9ad56ae15ee144ed10e33886777eb5ca2509a914850a5faa7b52ff459"
+      sha256: "5cf5fdcf853b0629deb35891c7af643be900c3dcaed7489009f9e7dbcfe55ab6"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.7"
+    version: "14.2.8"
   go_router_builder:
     dependency: "direct dev"
     description:
@@ -1210,10 +1210,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1242,10 +1242,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: f33d6bb662f0e4f79dcd7ada2e6170f3b3a2530c28fc41f49a411ddedd576a77
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.5.1"
   vector_graphics:
     dependency: "direct main"
     description:
@@ -1298,10 +1298,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   web_socket:
     dependency: transitive
     description:

--- a/apps/ticket_web/pubspec.yaml
+++ b/apps/ticket_web/pubspec.yaml
@@ -41,6 +41,13 @@ dev_dependencies:
   theme_tailor: ^3.0.1
   vector_graphics_compiler: ^1.1.11+1
 
+dependency_overrides:
+  yet_another_json_isolate:
+    git:
+      url: https://github.com/YumNumm/supabase-flutter.git
+      ref: 4edc00b3b70621d37814b8c1fbef448655a4b222
+      path: packages/yet_another_json_isolate
+
 flutter:
   uses-material-design: true
 

--- a/apps/ticket_web/pubspec.yaml
+++ b/apps/ticket_web/pubspec.yaml
@@ -45,7 +45,7 @@ dependency_overrides:
   vector_graphics:
     git:
       url: https://github.com/YumNumm/vector_graphics.git
-      ref: 8f7abd11cff39096b829e3810f7eb12474bc8e58
+      ref: ae04010d19feff0db4e5b1763aa43d340fa6fa5e
       path: packages/vector_graphics
   yet_another_json_isolate:
     git:

--- a/apps/ticket_web/pubspec.yaml
+++ b/apps/ticket_web/pubspec.yaml
@@ -47,6 +47,11 @@ dependency_overrides:
       url: https://github.com/YumNumm/supabase-flutter.git
       ref: 4edc00b3b70621d37814b8c1fbef448655a4b222
       path: packages/yet_another_json_isolate
+  vector_graphics:
+    git:
+      url: https://github.com/YumNumm/vector_graphics.git
+      ref: 8f7abd11cff39096b829e3810f7eb12474bc8e58
+      path: packages/vector_graphics
 
 flutter:
   uses-material-design: true

--- a/apps/ticket_web/pubspec.yaml
+++ b/apps/ticket_web/pubspec.yaml
@@ -42,16 +42,16 @@ dev_dependencies:
   vector_graphics_compiler: ^1.1.11+1
 
 dependency_overrides:
-  yet_another_json_isolate:
-    git:
-      url: https://github.com/YumNumm/supabase-flutter.git
-      ref: 4edc00b3b70621d37814b8c1fbef448655a4b222
-      path: packages/yet_another_json_isolate
   vector_graphics:
     git:
       url: https://github.com/YumNumm/vector_graphics.git
       ref: 8f7abd11cff39096b829e3810f7eb12474bc8e58
       path: packages/vector_graphics
+  yet_another_json_isolate:
+    git:
+      url: https://github.com/YumNumm/supabase-flutter.git
+      ref: 4edc00b3b70621d37814b8c1fbef448655a4b222
+      path: packages/yet_another_json_isolate
 
 flutter:
   uses-material-design: true

--- a/apps/website/pubspec.lock
+++ b/apps/website/pubspec.lock
@@ -1311,12 +1311,13 @@ packages:
     source: hosted
     version: "3.1.2"
   yet_another_json_isolate:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: yet_another_json_isolate
-      sha256: "47ed3900e6b0e4dfe378811a4402e85b7fc126a7daa94f840fef65ea9c8e46f4"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/yet_another_json_isolate"
+      ref: "4edc00b3b70621d37814b8c1fbef448655a4b222"
+      resolved-ref: "4edc00b3b70621d37814b8c1fbef448655a4b222"
+      url: "https://github.com/YumNumm/supabase-flutter.git"
+    source: git
     version: "2.0.2"
 sdks:
   dart: ">=3.6.0-216.1.beta <4.0.0"

--- a/apps/website/pubspec.lock
+++ b/apps/website/pubspec.lock
@@ -1201,10 +1201,11 @@ packages:
   vector_graphics:
     dependency: "direct main"
     description:
-      name: vector_graphics
-      sha256: "32c3c684e02f9bc0afb0ae0aa653337a2fe022e8ab064bcd7ffda27a74e288e3"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/vector_graphics"
+      ref: "8f7abd11cff39096b829e3810f7eb12474bc8e58"
+      resolved-ref: "8f7abd11cff39096b829e3810f7eb12474bc8e58"
+      url: "https://github.com/YumNumm/vector_graphics.git"
+    source: git
     version: "1.1.11+1"
   vector_graphics_codec:
     dependency: transitive

--- a/apps/website/pubspec.lock
+++ b/apps/website/pubspec.lock
@@ -1202,8 +1202,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/vector_graphics"
-      ref: "8f7abd11cff39096b829e3810f7eb12474bc8e58"
-      resolved-ref: "8f7abd11cff39096b829e3810f7eb12474bc8e58"
+      ref: ae04010d19feff0db4e5b1763aa43d340fa6fa5e
+      resolved-ref: ae04010d19feff0db4e5b1763aa43d340fa6fa5e
       url: "https://github.com/YumNumm/vector_graphics.git"
     source: git
     version: "1.1.11+1"

--- a/apps/website/pubspec.lock
+++ b/apps/website/pubspec.lock
@@ -413,10 +413,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "2ddb88e9ad56ae15ee144ed10e33886777eb5ca2509a914850a5faa7b52ff459"
+      sha256: "5cf5fdcf853b0629deb35891c7af643be900c3dcaed7489009f9e7dbcfe55ab6"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.7"
+    version: "14.2.8"
   gotrue:
     dependency: transitive
     description:
@@ -1162,10 +1162,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      sha256: "769549c999acdb42b8bcfa7c43d72bf79a382ca7441ab18a808e101149daf672"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1194,10 +1194,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: f33d6bb662f0e4f79dcd7ada2e6170f3b3a2530c28fc41f49a411ddedd576a77
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.5.1"
   vector_graphics:
     dependency: "direct main"
     description:
@@ -1250,10 +1250,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   web_socket:
     dependency: transitive
     description:

--- a/apps/website/pubspec.yaml
+++ b/apps/website/pubspec.yaml
@@ -40,6 +40,13 @@ dev_dependencies:
   theme_tailor: ^3.0.1
   vector_graphics_compiler: ^1.1.11+1
 
+dependency_overrides:
+  yet_another_json_isolate:
+    git:
+      url: https://github.com/YumNumm/supabase-flutter.git
+      ref: 4edc00b3b70621d37814b8c1fbef448655a4b222
+      path: packages/yet_another_json_isolate
+
 flutter:
   generate: true
   uses-material-design: true

--- a/apps/website/pubspec.yaml
+++ b/apps/website/pubspec.yaml
@@ -44,7 +44,7 @@ dependency_overrides:
   vector_graphics:
     git:
       url: https://github.com/YumNumm/vector_graphics.git
-      ref: 8f7abd11cff39096b829e3810f7eb12474bc8e58
+      ref: ae04010d19feff0db4e5b1763aa43d340fa6fa5e
       path: packages/vector_graphics
   yet_another_json_isolate:
     git:

--- a/apps/website/pubspec.yaml
+++ b/apps/website/pubspec.yaml
@@ -46,6 +46,11 @@ dependency_overrides:
       url: https://github.com/YumNumm/supabase-flutter.git
       ref: 4edc00b3b70621d37814b8c1fbef448655a4b222
       path: packages/yet_another_json_isolate
+  vector_graphics:
+    git:
+      url: https://github.com/YumNumm/vector_graphics.git
+      ref: 8f7abd11cff39096b829e3810f7eb12474bc8e58
+      path: packages/vector_graphics
 
 flutter:
   generate: true

--- a/apps/website/pubspec.yaml
+++ b/apps/website/pubspec.yaml
@@ -41,16 +41,16 @@ dev_dependencies:
   vector_graphics_compiler: ^1.1.11+1
 
 dependency_overrides:
-  yet_another_json_isolate:
-    git:
-      url: https://github.com/YumNumm/supabase-flutter.git
-      ref: 4edc00b3b70621d37814b8c1fbef448655a4b222
-      path: packages/yet_another_json_isolate
   vector_graphics:
     git:
       url: https://github.com/YumNumm/vector_graphics.git
       ref: 8f7abd11cff39096b829e3810f7eb12474bc8e58
       path: packages/vector_graphics
+  yet_another_json_isolate:
+    git:
+      url: https://github.com/YumNumm/supabase-flutter.git
+      ref: 4edc00b3b70621d37814b8c1fbef448655a4b222
+      path: packages/yet_another_json_isolate
 
 flutter:
   generate: true

--- a/packages/app/features/news/pubspec.yaml
+++ b/packages/app/features/news/pubspec.yaml
@@ -18,8 +18,8 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  hooks_riverpod: ^2.5.2
   flutter_svg: ^2.0.10+1
+  hooks_riverpod: ^2.5.2
   intl: ^0.19.0
   url_launcher: ^6.3.0
 
@@ -28,10 +28,8 @@ dev_dependencies:
     sdk: flutter
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
-
 # The following section is specific to Flutter packages.
 #flutter:
-
 # To add assets to your package, add an assets section, like this:
 # assets:
 #   - images/a_dot_burr.jpeg
@@ -42,7 +40,6 @@ dev_dependencies:
 #
 # An image asset can refer to one or more resolution-specific "variants", see
 # https://flutter.dev/assets-and-images/#resolution-aware
-
 # To add custom fonts to your package, add a fonts section here,
 # in this "flutter" section. Each entry in this list should have a
 # "family" key with the font family name, and a "fonts" key with a

--- a/packages/common/data/pubspec.lock
+++ b/packages/common/data/pubspec.lock
@@ -1107,12 +1107,13 @@ packages:
     source: hosted
     version: "3.1.2"
   yet_another_json_isolate:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: yet_another_json_isolate
-      sha256: "47ed3900e6b0e4dfe378811a4402e85b7fc126a7daa94f840fef65ea9c8e46f4"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/yet_another_json_isolate"
+      ref: "4edc00b3b70621d37814b8c1fbef448655a4b222"
+      resolved-ref: "4edc00b3b70621d37814b8c1fbef448655a4b222"
+      url: "https://github.com/YumNumm/supabase-flutter.git"
+    source: git
     version: "2.0.2"
 sdks:
   dart: ">=3.6.0-216.1.beta <4.0.0"

--- a/packages/common/data/pubspec.yaml
+++ b/packages/common/data/pubspec.yaml
@@ -26,3 +26,10 @@ dev_dependencies:
   riverpod_lint: ^2.3.13
   shared_preferences: ^2.2.3
   test: ^1.24.0
+
+dependency_overrides:
+  yet_another_json_isolate:
+    git:
+      url: https://github.com/YumNumm/supabase-flutter.git
+      ref: 4edc00b3b70621d37814b8c1fbef448655a4b222
+      path: packages/yet_another_json_isolate

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -261,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -317,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

- Dart 3.5以降かつdart2wasmを用いた場合に、`Supabase.initialize()`が正常に動いていなかった
  - 根本原因は　https://github.com/supabase/supabase-flutter/issues/1047
- 上記と同じ理由で、`vector_graphics`も正常動作していなかったので 修正版にoverrideしています

## 説明

- この問題を修正するPR https://github.com/supabase/supabase-flutter/pull/1048 のバージョンを利用するようにしました
  - 修正がマージされ、新しいバージョンがリリースされたら そちらを利用するように戻します


## その他

- [x] Appがビルド可能で動作すること
- [x] ticket_webがビルド可能で動作すること
- [x] webがビルド可能で動作すること 
