### PR TITLE
Improvement/integrate check jobs

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -1,0 +1,63 @@
+name: Check Pull Request
+
+on:
+  pull_request:
+
+concurrency:
+  group: check-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    uses: ./.github/workflows/wc-check-changes.yaml
+
+  skip-job-no-changes:
+    runs-on: ubuntu-22.04
+    needs: changes
+    if: ${{ needs.changes.outputs.any == 'false'}}
+    steps:
+      # https://github.com/peter-evans/create-or-update-comment
+      - name: Skip comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            チェック対象ファイルに変更がないため、ジョブの実行をスキップしました。
+
+  check-database:
+    needs: changes
+    if: ${{ needs.changes.outputs.database == 'true' }}
+    uses: ./.github/workflows/wc-check-database.yaml
+
+  check-markdownlint:
+    needs: changes
+    if: ${{ needs.changes.outputs.markdownlint == 'true' }}
+    uses: ./.github/workflows/wc-check-markdownlint.yaml
+
+  check-prettier:
+    needs: changes
+    if: ${{ needs.changes.outputs.prettier == 'true' }}
+    uses: ./.github/workflows/wc-check-prettier.yaml
+
+  check-sql-format:
+    needs: changes
+    if: ${{ needs.changes.outputs.sql-format == 'true' }}
+    uses: ./.github/workflows/wc-check-sql-format.yaml
+
+  check-textlint:
+    needs: changes
+    if: ${{ needs.changes.outputs.textlint == 'true' }}
+    uses: ./.github/workflows/wc-check-textlint.yaml
+
+  status-check:
+    runs-on: ubuntu-22.04
+    needs:
+      - check-database
+      - check-markdownlint
+      - check-prettier
+      - check-sql-format
+      - check-textlint
+    permissions: {}
+    if: failure()
+    steps:
+      - run: exit 1

--- a/.github/workflows/wc-check-changes.yaml
+++ b/.github/workflows/wc-check-changes.yaml
@@ -1,0 +1,56 @@
+name: Check Changes
+
+on:
+  workflow_call:
+    outputs:
+      any:
+        value: ${{ jobs.changes.outputs.any }}
+      database:
+        value: ${{ jobs.changes.outputs.database }}
+      markdownlint:
+        value: ${{ jobs.changes.outputs.markdownlint }}
+      prettier:
+        value: ${{ jobs.changes.outputs.prettier }}
+      sql-format:
+        value: ${{ jobs.changes.outputs.sql-format }}
+      textlint:
+        value: ${{ jobs.changes.outputs.textlint }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      any: ${{ steps.filter.outputs.changes != '[]' }}
+      database: ${{ steps.filter.outputs.database }}
+      markdownlint: ${{ steps.filter.outputs.markdownlint }}
+      prettier: ${{ steps.filter.outputs.prettier }}
+      sql-format: ${{ steps.filter.outputs.sql-format }}
+      textlint: ${{ steps.filter.outputs.textlint }}
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      # https://github.com/marketplace/actions/paths-changes-filter
+      - name: Paths Changes Filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            database:
+              - "packages/common/data/**.sql"
+            markdownlint:
+              - "**.md"
+            prettier:
+              - "**.json"
+              - "**.jsonc"
+              - "**.yaml"
+            sql-format:
+              - "packages/common/data/**.sql"
+            textlint:
+              - "**.md"
+              - "apps/app/**/**.arb"

--- a/.github/workflows/wc-check-database.yaml
+++ b/.github/workflows/wc-check-database.yaml
@@ -1,9 +1,7 @@
 name: Unit Test for Supabase Database
 
 on:
-  pull_request:
-    paths:
-      - "packages/common/data/**.sql"
+  workflow_call:
 
 jobs:
   unit-test:

--- a/.github/workflows/wc-check-markdownlint.yaml
+++ b/.github/workflows/wc-check-markdownlint.yaml
@@ -1,14 +1,10 @@
-name: Check Prettier
+name: Check markdownlint
 
 on:
-  pull_request:
-    paths:
-      - "**.json"
-      - "**.jsonc"
-      - "**.yaml"
+  workflow_call:
 
 jobs:
-  check-prettier:
+  check-markdownlint:
     runs-on: ubuntu-22.04
 
     timeout-minutes: 10
@@ -23,9 +19,6 @@ jobs:
           # This is important to fetch the changes to the previous commit
           fetch-depth: 0
 
-      # https://github.com/creyD/prettier_action
-      - name: Check Prettier
-        uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1 # v4.3
-        with:
-          dry: true
-          prettier_options: --config .prettierrc.yaml --check **/*.{json,jsonc,yaml}
+      # https://github.com/DavidAnson/markdownlint-cli2-action
+      - name: Check markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809 # v17.0.0

--- a/.github/workflows/wc-check-prettier.yaml
+++ b/.github/workflows/wc-check-prettier.yaml
@@ -1,12 +1,10 @@
-name: Check markdownlint
+name: Check Prettier
 
 on:
-  pull_request:
-    paths:
-      - "**.md"
+  workflow_call:
 
 jobs:
-  check-markdownlint:
+  check-prettier:
     runs-on: ubuntu-22.04
 
     timeout-minutes: 10
@@ -21,6 +19,9 @@ jobs:
           # This is important to fetch the changes to the previous commit
           fetch-depth: 0
 
-      # https://github.com/DavidAnson/markdownlint-cli2-action
-      - name: Check markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809 # v17.0.0
+      # https://github.com/creyD/prettier_action
+      - name: Check Prettier
+        uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1 # v4.3
+        with:
+          dry: true
+          prettier_options: --config .prettierrc.yaml --check **/*.{json,jsonc,yaml}

--- a/.github/workflows/wc-check-sql-format.yaml
+++ b/.github/workflows/wc-check-sql-format.yaml
@@ -1,9 +1,7 @@
 name: Check SQL Format
 
 on:
-  pull_request:
-    paths:
-      - "packages/common/data/**.sql"
+  workflow_call:
 
 env:
   PNPM_VERSION: 9

--- a/.github/workflows/wc-check-textlint.yaml
+++ b/.github/workflows/wc-check-textlint.yaml
@@ -1,10 +1,7 @@
 name: Check Textlint
 
 on:
-  pull_request:
-    paths:
-      - "**.md"
-      - "apps/app/**/**.arb"
+  workflow_call:
 
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
 permissions:

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,9 +1,11 @@
 {
   "words": [
     "designsystem",
+    "dorny",
     "IntelliJ",
     "Kaigi",
     "LTRB",
+    "markdownlint",
     "microtask",
     "MMMMEEE",
     "pubspec",
@@ -11,6 +13,7 @@
     "riverpod",
     "smallserial",
     "Supabase",
+    "textlint",
     "unawaited",
     "webp",
     "zenn"


### PR DESCRIPTION
## Issue

- Closes #271 

## 説明


ステータスチェックを１に絞るためには、次のようにすべてのチェックジョブの結果をまとめるジョブを作る必要があります。

```yaml
  status-check:
    runs-on: ubuntu-22.04
    needs:
      - check-xxx
      - check-yyy
      - check-zzz
    permissions: { }
    if: failure()
    steps:
      - run: exit 1
```

このようにするためにはワークフローからすべてのチェックジョブを呼び出す必要があります。

１つのワークフローファイルにジョブをまとめようとすると記述量が多くなってしまい可読性が低下してしまうため、Reusable Workflows として設定することにしました。

すでにゆめみのテンプレートプロジェクトでこの形でワークフローを作成済みです。

https://github.com/yumemi-inc/flutter-mobile-project-template/blob/main/.github/workflows/check-pr.yaml

## 画像 / 動画

見た目の変更なし。

## その他

マージ後にステータスチェックを設定予定です。

その他の今後やりたいことは ↓ に記載しています。

https://github.com/FlutterKaigi/2024/issues/194