### PR TITLE
ci: 生成ファイルの最新チェック用のワークフローを作成

### DIFF
--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -29,6 +29,11 @@ jobs:
     if: ${{ needs.changes.outputs.database == 'true' }}
     uses: ./.github/workflows/wc-check-database.yaml
 
+  check-diff:
+    needs: changes
+    if: ${{ needs.changes.outputs.diff == 'true' }}
+    uses: ./.github/workflows/wc-check-diff.yaml
+
   check-markdownlint:
     needs: changes
     if: ${{ needs.changes.outputs.markdownlint == 'true' }}
@@ -53,6 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - check-database
+      - check-diff
       - check-markdownlint
       - check-prettier
       - check-sql-format

--- a/.github/workflows/wc-check-changes.yaml
+++ b/.github/workflows/wc-check-changes.yaml
@@ -7,6 +7,8 @@ on:
         value: ${{ jobs.changes.outputs.any }}
       database:
         value: ${{ jobs.changes.outputs.database }}
+      diff:
+        value: ${{ jobs.changes.outputs.diff }}
       markdownlint:
         value: ${{ jobs.changes.outputs.markdownlint }}
       prettier:
@@ -26,6 +28,7 @@ jobs:
     outputs:
       any: ${{ steps.filter.outputs.changes != '[]' }}
       database: ${{ steps.filter.outputs.database }}
+      diff: ${{ steps.filter.outputs.diff }}
       markdownlint: ${{ steps.filter.outputs.markdownlint }}
       prettier: ${{ steps.filter.outputs.prettier }}
       sql-format: ${{ steps.filter.outputs.sql-format }}
@@ -43,6 +46,10 @@ jobs:
           filters: |
             database:
               - "packages/common/data/**.sql"
+            diff:
+              - "**.dart"
+              - "**.yaml"
+              - "**.pubspec.lock"
             markdownlint:
               - "**.md"
             prettier:

--- a/.github/workflows/wc-check-diff.yaml
+++ b/.github/workflows/wc-check-diff.yaml
@@ -1,0 +1,27 @@
+name: Check Diff
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check-diff:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Setup Application Runtime
+        uses: ./.github/actions/setup-application-runtime
+
+      - name: Rebuild
+        run: melos run rebuild --no-select
+
+      - name: Check diff
+        run: |
+          git add -N .
+          git diff --name-only --exit-code


### PR DESCRIPTION
## Issue

- Closes #274

## 説明

`melos run rebuild` コマンドを実行して Git の差分を確認するという生成ファイルの最新チェック用のワークフローを作成しました。

## 画像 / 動画

見た目への影響はないため省略します。

## その他

近いうちに build_runner のキャッシュについてのワークフローを組み込む予定です。