### PR TITLE
[ticket] (db): Postgres Viewの権限を修正

### DIFF
--- a/packages/common/data/supabase/migrations/20241003163730_fix_view_view_option.sql
+++ b/packages/common/data/supabase/migrations/20241003163730_fix_view_view_option.sql
@@ -1,0 +1,7 @@
+ALTER VIEW public.profiles_with_sns
+SET
+  (security_invoker = TRUE);
+
+ALTER VIEW public.session_venues_with_sessions
+SET
+  (security_invoker = TRUE);


### PR DESCRIPTION
## 概要
- Postgres Viewのうちいくつかが`SECURITY_DEFINER = TRUE`になっていた
  - これはRLSを回避可能にするフラグで、セキュリティ上好ましくない
  - `SECURITY_INVOKER = TRUE`にすることで、VIEWをSELECTしたユーザの権限で取得可能なもののみ返るようになります


https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0010_security_definer_view