### PR TITLE
[ticket] ticketPageにheaderAutomaticallyImplyLeadingを追加

### DIFF
--- a/apps/ticket_web/lib/core/components/site_scaffold.dart
+++ b/apps/ticket_web/lib/core/components/site_scaffold.dart
@@ -76,6 +76,7 @@ class SiteScaffold extends StatelessWidget {
           ? SiteHeader(
               onHeaderTitleTap: onHeaderTitleTap,
               actions: actions,
+              automaticallyImplyLeading: headerAutomaticallyImplyLeading,
             )
           : null,
       body: CustomScrollView(

--- a/apps/ticket_web/lib/pages/ticket/ticket_page.dart
+++ b/apps/ticket_web/lib/pages/ticket/ticket_page.dart
@@ -34,6 +34,7 @@ class TicketPage extends StatelessWidget {
         AppBarAvatar(),
         SizedBox(width: 8),
       ],
+      headerAutomaticallyImplyLeading: true,
       onHeaderTitleTap: () => HomeRoute().go(context),
       body: const ResponsiveContentContainer(
         child: _Body(),


### PR DESCRIPTION
## 概要
ページバックできることを示すボタンを`TicketPage`に追加
https://flutterkaigi.slack.com/archives/C07DX137CNB/p1728103532056209?thread_ts=1728102935.423529&cid=C07DX137CNB

![image](https://github.com/user-attachments/assets/5bdb3aef-e5e9-47be-8378-db7d9524bed0)
