### PR TITLE
[ticket] チケット画面の軽微なバグを修正

### DIFF
--- a/apps/ticket_web/lib/core/util/full_screen_loading.dart
+++ b/apps/ticket_web/lib/core/util/full_screen_loading.dart
@@ -13,6 +13,7 @@ class FullScreenCircularProgressIndicator extends StatelessWidget {
       showDialog<void>(
         context: context,
         builder: (context) => const FullScreenCircularProgressIndicator(),
+        barrierDismissible: false,
       ),
     );
     final T result;
@@ -28,6 +29,8 @@ class FullScreenCircularProgressIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const CircularProgressIndicator.adaptive();
+    return const Center(
+      child: CircularProgressIndicator.adaptive(),
+    );
   }
 }

--- a/apps/ticket_web/lib/feature/profile/data/profile_notifier.dart
+++ b/apps/ticket_web/lib/feature/profile/data/profile_notifier.dart
@@ -44,7 +44,6 @@ class ProfileNotifier extends _$ProfileNotifier {
     final pickedFile = await FilePicker.platform.pickFiles(
       allowedExtensions: ['png', 'jpg', 'jpeg'],
       type: FileType.custom,
-      lockParentWindow: true,
     );
     if (pickedFile == null) {
       throw ProfileAvatarException('Error: pickedFile is null');

--- a/apps/ticket_web/lib/feature/profile/data/profile_notifier.dart
+++ b/apps/ticket_web/lib/feature/profile/data/profile_notifier.dart
@@ -1,7 +1,6 @@
-import 'dart:typed_data';
-
 import 'package:common_data/profile.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:ticket_web/feature/auth/data/auth_notifier.dart';
 

--- a/apps/ticket_web/lib/feature/profile/data/profile_notifier.g.dart
+++ b/apps/ticket_web/lib/feature/profile/data/profile_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'profile_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$profileNotifierHash() => r'acebe826cf48299f34621b887bab95499666e25a';
+String _$profileNotifierHash() => r'4c8933f45a9d875ced89be087932a3b155961d6a';
 
 /// See also [ProfileNotifier].
 @ProviderFor(ProfileNotifier)

--- a/apps/ticket_web/lib/feature/ticket/ui/components/profile_avatar_choice_dialog.dart
+++ b/apps/ticket_web/lib/feature/ticket/ui/components/profile_avatar_choice_dialog.dart
@@ -50,6 +50,7 @@ class ProfileAvatarChoiceDialog extends HookConsumerWidget {
           const SizedBox(height: 16),
           ProfileAvatar(
             profile: profile.valueOrNull!,
+            canEdit: false,
           ),
           const SizedBox(height: 8),
           if (userAvatarState.valueOrNull != null)


### PR DESCRIPTION
## 説明

- チケット画面のバグを修正
  - `FullscreenLoadingScreen.showUntil()`関数
    - Android端末でCircularProgressIndicatorが全画面に広がって表示されてしまう問題を修正
    - 任意の領域をタップすることで、全画面読み込みブロッキングを解除できる問題を修正
  - プロフィール画像を選択する`ProfileAvatarChoiceDialog`が重なって表示される問題を修正


## 動画

- https://flutterkaigi.slack.com/archives/C07DX137CNB/p1728152617043339?thread_ts=1728112509.609509&cid=C07DX137CNB