### PR TITLE
[ticket] macOSでビルドできない問題を修正

### DIFF
--- a/apps/ticket_web/lib/core/provider/image_picker/image_picker_for_io.dart
+++ b/apps/ticket_web/lib/core/provider/image_picker/image_picker_for_io.dart
@@ -1,0 +1,7 @@
+import 'package:image_picker_macos/image_picker_macos.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'image_picker_for_io.g.dart';
+
+@Riverpod(keepAlive: true)
+ImagePickerMacOS imagePicker(ImagePickerRef ref) => ImagePickerMacOS();

--- a/apps/ticket_web/lib/core/provider/image_picker/image_picker_for_io.g.dart
+++ b/apps/ticket_web/lib/core/provider/image_picker/image_picker_for_io.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'image_picker_for_io.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$imagePickerHash() => r'c420c0acb8bbcbfa73455cac793cae9a01d84417';
+
+/// See also [imagePicker].
+@ProviderFor(imagePicker)
+final imagePickerProvider = Provider<ImagePickerMacOS>.internal(
+  imagePicker,
+  name: r'imagePickerProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$imagePickerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef ImagePickerRef = ProviderRef<ImagePickerMacOS>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/apps/ticket_web/lib/core/provider/image_picker/image_picker_for_web.dart
+++ b/apps/ticket_web/lib/core/provider/image_picker/image_picker_for_web.dart
@@ -1,0 +1,7 @@
+import 'package:image_picker_for_web/image_picker_for_web.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'image_picker_for_web.g.dart';
+
+@Riverpod(keepAlive: true)
+ImagePickerPlugin imagePicker(ImagePickerRef ref) => ImagePickerPlugin();

--- a/apps/ticket_web/lib/core/provider/image_picker/image_picker_for_web.g.dart
+++ b/apps/ticket_web/lib/core/provider/image_picker/image_picker_for_web.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'image_picker_provider.dart';
+part of 'image_picker_for_web.dart';
 
 // **************************************************************************
 // RiverpodGenerator

--- a/apps/ticket_web/lib/core/provider/image_picker_provider.dart
+++ b/apps/ticket_web/lib/core/provider/image_picker_provider.dart
@@ -1,7 +1,3 @@
-import 'package:image_picker_for_web/image_picker_for_web.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-part 'image_picker_provider.g.dart';
-
-@Riverpod(keepAlive: true)
-ImagePickerPlugin imagePicker(ImagePickerRef ref) => ImagePickerPlugin();
+export './image_picker/image_picker_for_io.dart'
+    if (dart.library.js_interop) './image_picker/image_picker_for_web.dart'
+    show ImagePickerRef, imagePicker, imagePickerProvider;

--- a/apps/ticket_web/lib/feature/profile/data/profile_notifier.dart
+++ b/apps/ticket_web/lib/feature/profile/data/profile_notifier.dart
@@ -44,6 +44,7 @@ class ProfileNotifier extends _$ProfileNotifier {
 
   Future<(Uint8List, String)> pickImage() async {
     final imagePicker = ref.read(imagePickerProvider);
+
     final image = await imagePicker.getImageFromSource(
       source: ImageSource.gallery,
     );

--- a/apps/ticket_web/pubspec.lock
+++ b/apps/ticket_web/pubspec.lock
@@ -459,10 +459,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "9ee02950848f61c4129af3d6ec84a1cfc0e47931abc746b03e7a3bc3e8ff6eda"
+      sha256: "9b78450b89f059e96c9ebb355fa6b3df1d6b330436e0b885fb49594c41721398"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.22"
+    version: "2.0.23"
   flutter_riverpod:
     dependency: transitive
     description:
@@ -645,10 +645,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: dbd24fc963d2e3e8dd55d9a965a50bab437f15c9d7015b38ceb70c858f9655bb
+      sha256: d3e5e00fdfeca8fd4ffb3227001264d449cc8950414c2ff70b0e06b9c628e643
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+14"
+    version: "0.8.12+15"
   image_picker_for_web:
     dependency: "direct main"
     description:
@@ -674,7 +674,7 @@ packages:
     source: hosted
     version: "0.2.1+1"
   image_picker_macos:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_macos
       sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"

--- a/apps/ticket_web/pubspec.yaml
+++ b/apps/ticket_web/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   image: ^4.2.0
   image_picker: ^1.1.2
   image_picker_for_web: ^3.0.5
+  image_picker_macos: ^0.2.1+1
   intl: ^0.19.0
   json_annotation: ^4.9.0
   riverpod_annotation: ^2.3.5


### PR DESCRIPTION
## 説明
- `image_picker_for_web` Packageに依存していたため、macOSのビルドが成功していなかった
  - プラットフォームごとにファイルを分割して、macOSでもビルド/動作できるようにしました