### PR TITLE
[ticket] 個人スポンサーチケットの検証フローを修正

### DIFF
--- a/api/src/routes/v1/v1.ts
+++ b/api/src/routes/v1/v1.ts
@@ -381,11 +381,11 @@ function getTicketType(
     | undefined,
   productType: v.InferOutput<typeof productTypeSchema>
 ): Database["public"]["Enums"]["ticket_type"] {
-  if (!promotionCodeMetadata) {
-    return "general";
-  }
   if (productType === "personal_sponsor") {
     return "individual_sponsor";
+  }
+  if (!promotionCodeMetadata) {
+    return "general";
   }
   switch (promotionCodeMetadata.type) {
     case "session": {


### PR DESCRIPTION
個人スポンサーにはプロモーションコードは存在しないため、先に分岐をする必要がある

- https://flutterkaigi.slack.com/archives/C07DX137CNB/p1728190903245129?thread_ts=1728102935.423529&cid=C07DX137CNB