### PR TITLE
[all] ci: build_runner のキャッシュについて build ディレクトリごとキャッシュするように変更

### DIFF
--- a/.github/workflows/update-application-cache.yaml
+++ b/.github/workflows/update-application-cache.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
         with:
           path: |
-            **/.dart_tool/build/generated
+            **/.dart_tool/build
           key: build-runner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pubspec.lock', '**/build.yaml', '**/assets/**/*.*') }}
 
       - name: Rebuild

--- a/.github/workflows/wc-check-diff.yaml
+++ b/.github/workflows/wc-check-diff.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
         with:
           path: |
-            **/.dart_tool/build/generated
+            **/.dart_tool/build
           key: build-runner-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pubspec.lock', '**/build.yaml', '**/assets/**/*.*') }}
           restore-keys: |
             build-runner-${{ runner.os }}-${{ runner.arch }}-


### PR DESCRIPTION
## Issue

なし

## 説明

- 以前 `**/.dart_tool/build/generated` ディレクトリ配下のみをキャッシュするようにしていたが、これだけだと容量が小さかったためか `melos run rebuild` の高速化には繋がらなかった。
- YUMEMI のプロジェクトでは `**/.dart_tool/build` ディレクトリ配下にしているが、現状問題発生しておらず高速化できている。
  - https://github.com/yumemi-inc/flutter-mobile-project-template/blob/6b68c4fdd5f631faab0d7b8d220987fe802cb5eb/.github/workflows/wc-check-diff.yaml#L27

## 画像 / 動画

なし

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
