### PR TITLE
[all] ci: パッケージのチェックワークフローに循環依存チェックを追加

### DIFF
--- a/.github/workflows/wc-check-packages.yaml
+++ b/.github/workflows/wc-check-packages.yaml
@@ -23,6 +23,9 @@ jobs:
       - name: Format
         run: melos format -c 5 --output none --set-exit-if-changed
 
+      - name: Circular Dependency
+        run: melos list --cycles
+
       # https://github.com/reviewdog/action-setup
       - uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
 


### PR DESCRIPTION
## Issue

- Closes #350 

## 説明

CI のパッケージチェック時に循環依存があったらエラーになるようにしました。

https://melos.invertase.dev/commands/list#--cycles

挙動は↓で確認済み
https://github.com/FlutterKaigi/2024/pull/356

## 画像 / 動画

なし

## その他


