### PR TITLE
fix: 最大枚数が不明なチケット種別ががある時の例外処理

### DIFF
--- a/api/src/features/cron/scheduled.ts
+++ b/api/src/features/cron/scheduled.ts
@@ -54,7 +54,7 @@ export async function scheduled(
             text:
               `*${getTicketType(
                 type as Database["public"]["Enums"]["ticket_type"]
-              )}*\n` + getProgressBarText(count, getMaxCount(ticketType) ?? 0)
+              )}*\n` + getProgressBarText(count, getMaxCount(ticketType))
           }
         };
       })
@@ -116,11 +116,15 @@ const getMaxCount = (type: Database["public"]["Enums"]["ticket_type"]) => {
   }
 };
 
-const getProgressBarText = (count: number, total: number) => {
-  const ratio = count / total;
-  const percentage = (ratio * 100).toFixed(2);
+const getProgressBarText = (count: number, total: number | undefined) => {
   const barLength = 30;
-  const bar = "▇".repeat(Math.floor(ratio * barLength));
-  const emptyBar = " ".repeat(barLength - bar.length);
-  return `\`[${bar}${emptyBar}] ${percentage}%\` : ${count}枚 / ${total}枚`;
+  if (total) {
+    const ratio = count / total;
+    const percentage = (ratio * 100).toFixed(2);
+    const bar = "▇".repeat(Math.floor(ratio * barLength));
+    const emptyBar = " ".repeat(barLength - bar.length);
+    return `\`[${bar}${emptyBar}] ${percentage}%\` : ${count}枚 / ${total}枚`;
+  }
+  const bar = "-".repeat(barLength);
+  return `\`[${bar}]\` : ${count}枚`;
 };


### PR DESCRIPTION
## 説明

- Slackのチケット枚数状況通知タスクの修正です
  - チケット枚数が不明なチケット種別 のチケットに対する分岐を追加しました

## めも
- https://flutterkaigi.slack.com/archives/C07R914V1FU/p1729173321916769 修正後の投稿
- エラー
![image](https://github.com/user-attachments/assets/3019736d-ffc4-490f-af27-5cc8bccd33c2)
