### PR TITLE
[All] ci: Issue テンプレートと Issue 作成時にラベル付与するワークフローを作成

### DIFF
--- a/.github/ISSUE_TEMPLATE/task_for_contributor.yaml
+++ b/.github/ISSUE_TEMPLATE/task_for_contributor.yaml
@@ -1,0 +1,44 @@
+name: 外部コントリビューターのタスク
+description: 外部コントリビューターのタスクを作成する
+title: "[Contributor]: "
+labels: ["role/contributor"]
+body:
+  - type: dropdown
+    id: related
+    attributes:
+      label: 関連するもの
+      description: このタスクが関連するものを選択してください。
+      multiple: false
+      options:
+        - "App"
+        - "Data"
+        - "Ticket"
+        - "Website"
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: タスクの種類
+      description: このタスクの種類を選択してください。
+      multiple: false
+      options:
+        - "Bug"
+        - "Feature"
+        - "Improvement"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: このタスクの目的や背景について簡潔に記述してください。
+    validations:
+      required: false
+  - type: textarea
+    id: references
+    attributes:
+      label: 参考文献
+      description: このタスクに関連する参考文献やリソースを記載してください。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task_for_staff.yaml
+++ b/.github/ISSUE_TEMPLATE/task_for_staff.yaml
@@ -1,0 +1,44 @@
+name: FlutterKaigi スタッフのタスク
+description: FlutterKaigi スタッフのタスクを作成する
+title: "[Staff]: "
+labels: ["role/staff"]
+body:
+  - type: dropdown
+    id: related
+    attributes:
+      label: 関連するもの
+      description: このタスクが関連するものを選択してください。
+      multiple: false
+      options:
+        - "App"
+        - "Data"
+        - "Ticket"
+        - "Website"
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: タスクの種類
+      description: このタスクの種類を選択してください。
+      multiple: false
+      options:
+        - "Bug"
+        - "Feature"
+        - "Improvement"
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: このタスクの目的や背景について簡潔に記述してください。
+    validations:
+      required: false
+  - type: textarea
+    id: references
+    attributes:
+      label: 参考文献
+      description: このタスクに関連する参考文献やリソースを記載してください。
+    validations:
+      required: false

--- a/.github/labeler-issue.yaml
+++ b/.github/labeler-issue.yaml
@@ -1,0 +1,23 @@
+policy:
+  - template: ["task_for_contributor.yaml", "task_for_staff.yaml"]
+    section:
+      - id: ["related"]
+        block-list: []
+        label:
+          - name: "related/app"
+            keys: ["App"]
+          - name: "related/data"
+            keys: ["Data"]
+          - name: "related/ticket"
+            keys: ["Ticket"]
+          - name: "related/website"
+            keys: ["Website"]
+      - id: [type]
+        block-list: []
+        label:
+          - name: "type/bug"
+            keys: ["Bug"]
+          - name: "type/feature"
+            keys: ["Feature"]
+          - name: "related/improvement"
+            keys: ["Improvement"]

--- a/.github/workflows/labeler-issue.yaml
+++ b/.github/workflows/labeler-issue.yaml
@@ -1,0 +1,41 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  labeler-issue:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    strategy:
+      matrix:
+        template:
+          - task_for_contributor.yaml
+          - task_for_staff.yaml
+
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      # https://github.com/stefanbuck/github-issue-parser
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@2d2ff50d4aae06ab58d26bf59468d98086605f11 # v3.2.1
+        id: issue-parser
+        with:
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      # https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
+      - name: Set labels based on severity field
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@d498805e5c7c0658e336948b3363480bcfd68da6 # v3.2.0
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          config: .github/labeler-contributor-issue.yaml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -15,6 +15,7 @@
     "reviewdog",
     "riverpod",
     "smallserial",
+    "stefanbuck",
     "subosito",
     "Supabase",
     "textlint",


### PR DESCRIPTION
## Issue

なし

## 説明

**※ #364 がマージされてからマージします。**

- 外部コントリビューター用に Issue テンプレートを作成しました。
- FlutterKaigi スタッフ用の Issue テンプレートはすでにありますが、新たに作成しています。既存の Issue テンプレートはもう少し落ち着いてから削除予定です。

## 画像 / 動画

なし

## その他

- https://github.com/stefanbuck/github-issue-parser
- https://github.com/redhat-plumbers-in-action/advanced-issue-labeler
- https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow