### PR TITLE
fix: コントリビューター一覧の取得方法を修正

### DIFF
--- a/.github/workflows/deploy-supabase.yaml
+++ b/.github/workflows/deploy-supabase.yaml
@@ -52,7 +52,10 @@ jobs:
       - run: supabase db push
         working-directory: packages/common/data
 
-      - run: supabase functions deploy --project-ref $PROJECT_ID
+      - run: |
+          supabase functions deploy --project-ref $PROJECT_ID
+          # replace_contributors のみ JWT での認証チェックをしない
+          supabase functions deploy replace_contributors --project-ref $PROJECT_ID --no-verify-jwt
         working-directory: packages/common/data
 
         # https://github.com/bobheadxi/deployments

--- a/.github/workflows/replace-contributors.yaml
+++ b/.github/workflows/replace-contributors.yaml
@@ -36,7 +36,7 @@ jobs:
           curl -i --location --request POST 'https://xflwrlgfukzpgkudzrlu.supabase.co/functions/v1/replace-contributors' \
             --header 'Authorization: Bearer ${{ secrets.EDGE_FUNCTION_ACCESS_TOKEN_CONTRIBUTORS_REPLACEMENT }}' \
             --header 'Content-Type: application/json' \
-            --data "${{ steps.contributors.outputs.result }}"
+            --data '${{ steps.contributors.outputs.result }}'
 
   notify-failure:
     needs: replace-contributors

--- a/.github/workflows/replace-contributors.yaml
+++ b/.github/workflows/replace-contributors.yaml
@@ -22,11 +22,13 @@ jobs:
 
             const contributors = response.data;
 
-            const formattedContributors = contributors.map(contributor => ({
-              name: contributor.login,
-              avatar_url: contributor.avatar_url,
-              contribution_count: contributor.contributions
-            }));
+            const formattedContributors = contributors
+              .filter(contributor => contributor.type === 'User')
+              .map(contributor => ({
+                name: contributor.login,
+                avatar_url: contributor.avatar_url,
+                contribution_count: contributor.contributions
+              }));
 
             console.log("Formatted contributors:", formattedContributors);
             return JSON.stringify(formattedContributors);

--- a/.github/workflows/replace-contributors.yaml
+++ b/.github/workflows/replace-contributors.yaml
@@ -15,10 +15,12 @@ jobs:
         with:
           result-encoding: string
           script: |
-            const contributors = await github.rest.repos.listContributors({
+            const response = await github.rest.repos.listContributors({
               owner: context.repo.owner,
               repo: context.repo.repo
             });
+
+            const contributors = response.data;
 
             const formattedContributors = contributors.map(contributor => ({
               name: contributor.login,
@@ -27,7 +29,7 @@ jobs:
             }));
 
             console.log("Formatted contributors:", formattedContributors);
-            return formattedContributors;
+            return JSON.stringify(formattedContributors);
 
       - name: Replace contributors via Supabase Edge Function
         run: |


### PR DESCRIPTION
## Issue

なし

## 説明

- コントリビューター一覧の取得方法を `const contributors = response.data;` のように修正
- コントリビューター一覧の取得結果を次のステップに渡すときに `JSON.stringify()` を利用
- コントリビューター一覧を通常ユーザーのみにフィルタリング（botユーザーを排除）
- `replace_contributors` のみ JWT での認証チェックをしないように修正
  - こうしないと認証チェックがデプロイのたびに必須になる

## 画像 / 動画

無事にデータを入れることできました 🎉 

<img width="765" alt="image" src="https://github.com/user-attachments/assets/5c3d7d18-842d-481a-85ee-a317e8ff45e1">

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
