### PR TITLE
[ticket-api] `flutterkaigi.jp`ドメインをCORSの`Access-Control-Allow-Origin`に追加

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -24,7 +24,8 @@ app.use(
       if (
         origin.startsWith("https://") &&
         (origin.endsWith("flutterkaigi-ticket-2024.pages.dev") ||
-          origin.endsWith("flutterkaigi-ticket-2024-staging.pages.dev"))
+          origin.endsWith("flutterkaigi-ticket-2024-staging.pages.dev") ||
+          origin.endsWith("flutterkaigi.jp"))
       ) {
         return origin;
       }


### PR DESCRIPTION
## 説明

- チケットシステムAPIのCORSに`flutterkaigi.jp`ドメインを追加します
  - チケットシステムを`flutterkaigi.jp`のサブドメインに移行する準備です