### PR TITLE
[All] chore: すべてに関係する Issue を作成できるように改善

### DIFF
--- a/.github/ISSUE_TEMPLATE/task_for_contributor.yaml
+++ b/.github/ISSUE_TEMPLATE/task_for_contributor.yaml
@@ -14,6 +14,7 @@ body:
         - "Data"
         - "Ticket"
         - "Website"
+        - "All"
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/task_for_staff.yaml
+++ b/.github/ISSUE_TEMPLATE/task_for_staff.yaml
@@ -14,6 +14,7 @@ body:
         - "Data"
         - "Ticket"
         - "Website"
+        - "All"
     validations:
       required: true
   - type: dropdown

--- a/.github/labeler-issue.yaml
+++ b/.github/labeler-issue.yaml
@@ -5,13 +5,13 @@ policy:
         block-list: []
         label:
           - name: "related/app"
-            keys: ["App"]
+            keys: ["App", "All"]
           - name: "related/data"
-            keys: ["Data"]
+            keys: ["Data", "All"]
           - name: "related/ticket"
-            keys: ["Ticket"]
+            keys: ["Ticket", "All"]
           - name: "related/website"
-            keys: ["Website"]
+            keys: ["Website", "All"]
       - id: [type]
         block-list: []
         label:


### PR DESCRIPTION
## Issue

なし

## 説明

現状の Issue テンプレートだとすべてに関連するもの（ `.DS_Store` がコミットされている件など ）を作成することができなかった。

## 画像 / 動画

### .github/ISSUE_TEMPLATE/task_for_contributor.yaml

<img width="695" alt="image" src="https://github.com/user-attachments/assets/c379f160-37f1-463a-9d21-7140d281ff6f">

### .github/ISSUE_TEMPLATE/task_for_staff.yaml

<img width="666" alt="image" src="https://github.com/user-attachments/assets/de5a74f1-d09f-4bd2-a93b-097f77fdcf6d">

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
