### PR TITLE
fetch contributions in descending order

### DIFF
--- a/packages/common/data/lib/src/repository/contributor_repository.dart
+++ b/packages/common/data/lib/src/repository/contributor_repository.dart
@@ -25,6 +25,7 @@ final class ContributorRepository {
     final contributors = await _supabaseClient
         .from('contributors')
         .select('name, avatar_url, contribution_count')
+        .order('contribution_count', ascending: false)
         .withConverter(
           (json) => json.map(Contributor.fromJson).toList(),
         );


### PR DESCRIPTION
## Issue

- Closes https://github.com/FlutterKaigi/2024/issues/397

## 説明

- コントリビューターについて、コントリビューション数の降順で取得するように対応しました

## 画像 / 動画
-  対応後のコントリビューター一覧

<img src=https://github.com/user-attachments/assets/1c90e562-7d6b-49a9-96ca-28b7c0ae5291  width=300>

- ログ出力で確認

<img src=https://github.com/user-attachments/assets/6acda93b-5bdf-4017-b23b-c4a09d88591d  width=100%>





## その他
- 特にありません
<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
