### PR TITLE
[App] feat: パッケージ名を環境ごとに設定

### DIFF
--- a/apps/app/android/app/build.gradle
+++ b/apps/app/android/app/build.gradle
@@ -49,6 +49,9 @@ android {
 
     defaultConfig {
         applicationId = "jp.flutterkaigi.conf2024"
+        if (dartDefines.APP_ID_SUFFIX != null) {
+            applicationIdSuffix = ".${dartDefines.APP_ID_SUFFIX}"
+        }
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = flutter.minSdkVersion

--- a/apps/app/defines/development.env
+++ b/apps/app/defines/development.env
@@ -1,3 +1,4 @@
 APP_NAME="dev FlutterKaigi 2024"
+APP_ID_SUFFIX="dev"
 SUPABASE_URL="http://localhost:54321"
 SUPABASE_ANON_KEY=""

--- a/apps/app/lib/main.dart
+++ b/apps/app/lib/main.dart
@@ -30,6 +30,7 @@ void main() async {
   await supabaseInitializer.initialize();
 
   await initSharedPreferencesInstance();
+  await initPackageInfoInstance();
 
   runApp(
     const ProviderScope(

--- a/apps/app/pubspec.lock
+++ b/apps/app/pubspec.lock
@@ -681,6 +681,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -1214,6 +1230,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/melos.yaml
+++ b/melos.yaml
@@ -21,6 +21,7 @@ command:
       riverpod: ^2.6.1
       hooks_riverpod: ^2.6.1
       json_annotation: ^4.9.0
+      package_info_plus: ^8.0.0
       riverpod_annotation: ^2.3.5
       supabase_flutter: ^2.6.0
       intl: ^0.19.0

--- a/packages/app/cores/core/lib/providers.dart
+++ b/packages/app/cores/core/lib/providers.dart
@@ -1,1 +1,2 @@
+export 'src/providers/package_info_instance.dart';
 export 'src/providers/shared_preferences_instance.dart';

--- a/packages/app/cores/core/lib/src/providers/package_info_instance.dart
+++ b/packages/app/cores/core/lib/src/providers/package_info_instance.dart
@@ -1,0 +1,21 @@
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'package_info_instance.g.dart';
+
+late PackageInfo _packageInfo;
+
+/// [PackageInfo] instance initialization.
+Future<void> initPackageInfoInstance({
+  PackageInfo? packageInfo,
+}) async {
+  _packageInfo = packageInfo ?? await PackageInfo.fromPlatform();
+}
+
+/// This provider requires calling [initPackageInfoInstance] in advance.
+@riverpod
+PackageInfo packageInfoInstance(
+  Ref ref,
+) =>
+    _packageInfo;

--- a/packages/app/cores/core/lib/src/providers/package_info_instance.g.dart
+++ b/packages/app/cores/core/lib/src/providers/package_info_instance.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'package_info_instance.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$packageInfoInstanceHash() =>
+    r'8aedcfa30a09f3cb2f7bc939721181138a693a3b';
+
+/// This provider requires calling [initPackageInfoInstance] in advance.
+///
+/// Copied from [packageInfoInstance].
+@ProviderFor(packageInfoInstance)
+final packageInfoInstanceProvider = AutoDisposeProvider<PackageInfo>.internal(
+  packageInfoInstance,
+  name: r'packageInfoInstanceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$packageInfoInstanceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef PackageInfoInstanceRef = AutoDisposeProviderRef<PackageInfo>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/app/cores/core/pubspec.lock
+++ b/packages/app/cores/core/pubspec.lock
@@ -373,6 +373,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
   http_multi_server:
     dependency: transitive
     description:
@@ -501,6 +509,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -954,6 +978,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/packages/app/cores/core/pubspec.yaml
+++ b/packages/app/cores/core/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   hooks_riverpod: ^2.6.1
+  package_info_plus: ^8.0.0
   riverpod: ^2.6.1
   riverpod_annotation: ^2.3.5
   shared_preferences: ^2.3.2

--- a/packages/app/cores/designsystem/pubspec.lock
+++ b/packages/app/cores/designsystem/pubspec.lock
@@ -532,6 +532,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -1017,6 +1033,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/packages/app/cores/settings/pubspec.lock
+++ b/packages/app/cores/settings/pubspec.lock
@@ -456,6 +456,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -893,6 +909,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/packages/app/features/about/lib/src/ui/about_page.dart
+++ b/packages/app/features/about/lib/src/ui/about_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app_cores_core/providers.dart';
 import 'package:app_cores_core/util.dart';
 import 'package:app_cores_designsystem/common_assets.dart';
 import 'package:app_cores_designsystem/ui.dart';
@@ -12,16 +13,24 @@ import 'package:app_features_about/src/ui/staff/staff_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:gap/gap.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-class AboutPage extends StatelessWidget {
+class AboutPage extends ConsumerWidget {
   const AboutPage({
     super.key,
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l = L10nAbout.of(context);
     final theme = Theme.of(context);
+
+    final appVersion = ref.watch(
+      packageInfoInstanceProvider.select(
+        (p) => '${p.version}+${p.buildNumber} ( ${p.packageName} )',
+      ),
+    );
+
     return Scaffold(
       body: CustomScrollView(
         slivers: [
@@ -164,6 +173,8 @@ class AboutPage extends StatelessWidget {
                       MaterialPageRoute<void>(
                         builder: (context) => LicensePage(
                           applicationName: l.applicationName,
+                          applicationVersion: appVersion,
+                          applicationLegalese: '© 2024 FlutterKaigi',
                         ),
                       ),
                     ),

--- a/packages/app/features/about/pubspec.lock
+++ b/packages/app/features/about/pubspec.lock
@@ -361,6 +361,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -790,6 +806,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/packages/app/features/news/pubspec.lock
+++ b/packages/app/features/news/pubspec.lock
@@ -353,6 +353,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -782,6 +798,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/packages/app/features/session/pubspec.lock
+++ b/packages/app/features/session/pubspec.lock
@@ -551,6 +551,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -1036,6 +1052,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/packages/app/features/venue/pubspec.lock
+++ b/packages/app/features/venue/pubspec.lock
@@ -116,6 +116,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "76d306a1c3afb33fe82e2bbacad62a61f409b5634c915fceb0d799de1a913360"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
   intl:
     dependency: "direct main"
     description:
@@ -172,6 +188,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: df3eb3e0aed5c1107bb0fdb80a8e82e778114958b1c5ac5644fb1ac9cae8a998
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -353,6 +385,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.3"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   url_launcher:
     dependency: transitive
     description:
@@ -441,6 +481,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: e1d0cc62e65dc2561f5071fcbccecf58ff20c344f8f3dc7d4922df372a11df1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.7.1"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
## Issue

#413 

## 説明

- 開発環境用のパッケージ名のサフィックスに `.dev` を追加
- ライセンスページにバージョンとパッケージ名、アプリのライセンス表記を表示

## 画像 / 動画

| 開発環境 | 本番環境 |
|-|-|
| <img src=https://github.com/user-attachments/assets/ffa6ac50-4c5a-4c5f-bba0-4c30a03adf09 width=320 /> | <img src=https://github.com/user-attachments/assets/9fc4f282-6f23-4acc-8136-790afbfad8a7 width=320 /> |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
