### PR TITLE
[App] chore: アプリの appbundle のビルド設定を追加

### DIFF
--- a/.github/workflows/deploy-app-android.yaml
+++ b/.github/workflows/deploy-app-android.yaml
@@ -1,0 +1,25 @@
+name: Deploy App Android
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: environment
+        required: true
+        type: choice
+        options:
+          - "flutterkaigi-app-2024-development"
+          - "flutterkaigi-app-2024-production"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-app-android:
+    runs-on: ubuntu-22.04
+    environment: ${{ github.event.inputs.environment }}
+    timeout-minutes: 20
+
+    steps:
+      - run: echo "Test"
+

--- a/.github/workflows/deploy-app-android.yaml
+++ b/.github/workflows/deploy-app-android.yaml
@@ -22,4 +22,3 @@ jobs:
 
     steps:
       - run: echo "Test"
-

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,5 +1,6 @@
 {
   "words": [
+    "appbundle",
     "Ariake",
     "designsystem",
     "dorny",

--- a/apps/app/android/app/build.gradle
+++ b/apps/app/android/app/build.gradle
@@ -33,6 +33,14 @@ if (project.hasProperty('dart-defines')) {
             }
 }
 
+def keyProperties = new Properties()
+def keyPropertiesFile = rootProject.file("key.properties")
+if (keyPropertiesFile.exists()) {
+    keyPropertiesFile.withReader('UTF-8') { reader ->
+        keyProperties.load(reader)
+    }
+}
+
 android {
     namespace = "jp.flutterkaigi.conf2024"
     compileSdk = flutter.compileSdkVersion
@@ -61,11 +69,18 @@ android {
         resValue "string", "appLabel", "${dartDefines.APP_NAME}"
     }
 
+    signingConfigs {
+        release {
+            keyAlias keyProperties.getProperty('keyAlias')
+            keyPassword keyProperties.getProperty('keyPassword')
+            storeFile rootProject.file(keyProperties.getProperty('keyStoreFilePath'))
+            storePassword keyProperties.getProperty('keyStorePassword')
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.debug
+            signingConfig = signingConfigs.release
         }
     }
 }

--- a/apps/app/android/app/build.gradle
+++ b/apps/app/android/app/build.gradle
@@ -81,6 +81,9 @@ android {
     buildTypes {
         release {
             signingConfig = signingConfigs.release
+            ndk {
+                debugSymbolLevel = 'SYMBOL_TABLE'
+            }
         }
     }
 }

--- a/apps/app/android/fastlane/Fastfile
+++ b/apps/app/android/fastlane/Fastfile
@@ -1,0 +1,17 @@
+default_platform(:android)
+
+platform :android do
+  lane :deploy_internal do
+    json_key_data = Base64.strict_decode64(ENV['SERVICE_ACCOUNT_KEY_BASE64'])
+
+    package_name = ENV['PACKAGE_NAME']
+
+    upload_to_play_store(
+      package_name: package_name,
+      track: 'internal',
+      release_status: 'draft',
+      aab: '../build/app/outputs/bundle/release/app-release.aab',
+      json_key_data: json_key_data,
+    )
+  end
+end

--- a/apps/app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/apps/app/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/apps/app/android/settings.gradle
+++ b/apps/app/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.1.2' apply false
+    id "com.android.application" version '8.3.2' apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -72,6 +72,10 @@ scripts:
     exec: flutter test
     packageFilters:
       dependsOn: flutter_test
+  app:build:appbundle:production:
+    exec: flutter build appbundle --dart-define-from-file=defines/production.env
+    packageFilters:
+      scope: conference_2024_app
 
 ide:
   intellij:


### PR DESCRIPTION
## Issue

#413 

## 説明

- Android アプリのビルド設定を Gradle, Melos に追加
- 最新の　Android Studio に対応するために Gradle のバージョンを更新
- 仮のデプロイワークフローファイルを作成
- apps/app/android/fastlane/Fastfile を仮作成

## 画像 / 動画

ちゃんと手元でビルドできることは確認済み。別でワークフロー作成のプルリクエスト提出予定です。

https://github.com/user-attachments/assets/a3840006-d6e3-4a08-b4e0-c9877526a195

## その他

- Android Gradle プラグインの 8.3 系の最新は 8.3.2
  - https://developer.android.com/build/releases/past-releases/agp-8-3-0-release-notes?hl=ja#patch-releases
- Gradle は 8.4 に上げなければならない
  - https://developer.android.com/build/releases/past-releases/agp-8-3-0-release-notes?hl=ja#compatibility
