### PR TITLE
[App] スタッフメンバー一覧のタップイベントを追加

### DIFF
--- a/packages/app/features/about/lib/src/ui/staff/staff_list_item.dart
+++ b/packages/app/features/about/lib/src/ui/staff/staff_list_item.dart
@@ -1,3 +1,4 @@
+import 'package:app_cores_core/util.dart';
 import 'package:app_cores_designsystem/common_assets.dart';
 import 'package:common_data/staff.dart';
 import 'package:flutter/foundation.dart';
@@ -19,6 +20,12 @@ class StaffListItem extends StatelessWidget {
     final theme = Theme.of(context);
 
     return ListTile(
+      onTap: () async {
+        final githubAccount = staff.snsAccounts.firstWhere(
+          (account) => account.type == SnsType.github,
+        );
+        await launchInExternalApp(githubAccount.link);
+      },
       leading: Image.network(
         staff.iconUrl.toString(),
         width: _imageSize,


### PR DESCRIPTION
## Issue

- Closes #396

## 説明

スタッフメンバー一覧でスタッフをタップした際、その人のGitHubページに遷移するようにしました。

## 画像 / 動画

https://github.com/user-attachments/assets/bccaa5a8-3d56-447a-8dbe-ca639c2dd734


