### PR TITLE
[App] fix: key.properties ファイルが存在するときのみ記載するように修正

### DIFF
--- a/apps/app/android/app/build.gradle
+++ b/apps/app/android/app/build.gradle
@@ -71,10 +71,12 @@ android {
 
     signingConfigs {
         release {
-            keyAlias keyProperties.getProperty('keyAlias')
-            keyPassword keyProperties.getProperty('keyPassword')
-            storeFile rootProject.file(keyProperties.getProperty('keyStoreFilePath'))
-            storePassword keyProperties.getProperty('keyStorePassword')
+            if (keyPropertiesFile.exists()) {
+                keyAlias keyProperties.getProperty('keyAlias')
+                keyPassword keyProperties.getProperty('keyPassword')
+                storeFile rootProject.file(keyProperties.getProperty('keyStoreFilePath'))
+                storePassword keyProperties.getProperty('keyStorePassword')
+            }
         }
     }
 


### PR DESCRIPTION
## Issue

- Closes #444 

## 説明

`key.properties` ファイルが存在しないときにも設定値を読み込むようになっており、一部のメンバーのみしかビルドができない状態になっていたため、ファイルの存在チェックをするようにしました。

## 画像 / 動画

`key.properties` ファイルを削除しても無事にビルドができ、アプリが起動するところまで確認できました。

<img src=https://github.com/user-attachments/assets/e7f73074-264c-4070-a6e0-c2db500a7590 width=320 />

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
