### PR TITLE
Fix Google login purchase button

### DIFF
--- a/apps/ticket_web/lib/core/i18n/strings.i18n.json
+++ b/apps/ticket_web/lib/core/i18n/strings.i18n.json
@@ -93,7 +93,9 @@
       "student": {
         "name": "学割について",
         "description": "FlutterKaigi 2024当日に、学生(高校・大学(短期大学,大学院を含む)・高等専門学校・専修学校・専門学校・職業訓練学校)の方は受付にて学生証を提示することによりチケット代金全額を返金致します。\n※返金は当日のみ有効です。また、一般チケットのみ対象となります。所属している教育機関が対象かどうか不明な場合は、運営にお問い合わせください。"
-      }
+      },
+      "loginWithGoogleToPurchase": "Googleでログインして購入",
+      "signInWithGoogleToPurchase": "Sign in with Google to purchase"
     }
   },
   "verify_purchase": {

--- a/apps/ticket_web/lib/pages/home/components/ticket_cards/general_ticket_card.dart
+++ b/apps/ticket_web/lib/pages/home/components/ticket_cards/general_ticket_card.dart
@@ -75,9 +75,11 @@ class GeneralTicketCard extends HookWidget {
                 padding:
                     const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
               ),
-              onPressed: isLoggedIn ? onPurchasePressed : null,
+              onPressed: isLoggedIn ? onPurchasePressed : onSignInPressed,
               icon: const Icon(Icons.shopping_cart),
-              label: Text(i18n.homePage.tickets.buyTicket),
+              label: Text(isLoggedIn
+                  ? i18n.homePage.tickets.buyTicket
+                  : i18n.homePage.tickets.loginWithGoogleToPurchase),
             ),
             const SizedBox(height: 8),
             const Divider(),

--- a/apps/ticket_web/lib/pages/home/components/ticket_cards/personal_sponsor_ticket_card.dart
+++ b/apps/ticket_web/lib/pages/home/components/ticket_cards/personal_sponsor_ticket_card.dart
@@ -78,7 +78,9 @@ class PersonalSponsorTicketCard extends StatelessWidget {
               ),
               onPressed: isLoggedIn ? onPurchasePressed : null,
               icon: const Icon(Icons.shopping_cart),
-              label: Text(i18n.homePage.tickets.buyTicket),
+              label: Text(isLoggedIn
+                  ? i18n.homePage.tickets.buyTicket
+                  : i18n.homePage.tickets.loginWithGoogleToPurchase),
             ),
           ],
         ),


### PR DESCRIPTION
Fixes #461

Update purchase button text for non-logged-in users

* Modify `general_ticket_card.dart` to change the purchase button text to 'Googleでログインして購入' if the user is not logged in.
* Modify `personal_sponsor_ticket_card.dart` to change the purchase button text to 'Googleでログインして購入' if the user is not logged in.
* Update `strings.i18n.json` to include new key-value pairs for 'Googleでログインして購入' and 'Sign in with Google to purchase'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FlutterKaigi/2024/issues/461?shareId=69b78197-3c47-4cb7-ba7d-529307c9b177).