### PR TITLE
[website] Faviconが表示されていない問題の修正

### DIFF
--- a/apps/website/web/index.html
+++ b/apps/website/web/index.html
@@ -34,7 +34,7 @@
     <meta name="apple-mobile-web-app-title" content="FlutterKaigi 2024" />
 
     <!-- Favicon -->
-    <link rel="icon" href="/2024/assets/assets/images/icon.webp" />
+    <link rel="icon" href="/assets/assets/images/icon.webp" />
     <!-- 192x192px -->
 
     <!-- Google Analytics 4 -->


### PR DESCRIPTION
## 説明
- `2024.flutterkaigi.jp`に変更した際に、Faviconの変更が抜けていたのでこちらで対応します