### PR TITLE
fix: セッション詳細画面でのタイトルの見切れを修正

### DIFF
--- a/packages/app/features/session/lib/src/ui/session_page.dart
+++ b/packages/app/features/session/lib/src/ui/session_page.dart
@@ -19,8 +19,8 @@ import 'package:intl/intl.dart' as intl;
 final _dateFormatter = intl.DateFormat.Md();
 final _timeFormatter = intl.DateFormat.Hm();
 
-class SessionPage extends ConsumerWidget {
-  const SessionPage({
+class SessionPage extends ConsumerWidget with SessionPageMixin {
+  SessionPage({
     required this.sessionId,
     super.key,
   });
@@ -55,6 +55,10 @@ class SessionPage extends ConsumerWidget {
           slivers: [
             SliverAppBar.large(
               title: Text(session.title),
+              expandedHeight: getExpandedHeight(
+                title: session.title,
+                context: context,
+              ),
               actions: [
                 IconButton(
                   tooltip: l.shareOnX,
@@ -166,5 +170,31 @@ class SessionPage extends ConsumerWidget {
     final startTime = _timeFormatter.format(startsAt);
     final endTime = _timeFormatter.format(endsAt);
     return '$startDate $startTime~$endTime';
+  }
+}
+
+// MEMO(@chippy-ao): Widget に書くと邪魔なので、mixin に出しました
+mixin SessionPageMixin {
+  final appBarSize = AppBar().preferredSize.height;
+  final padding = 16;
+
+  /// title の長さに応じて、SliverAppBar の expandedHeight を計算します
+  double getExpandedHeight({
+    required String title,
+    required BuildContext context,
+    bool forLarge = true,
+  }) {
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: title,
+        style: forLarge
+            ? Theme.of(context).textTheme.headlineMedium
+            : Theme.of(context).textTheme.headlineSmall,
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout(
+        maxWidth: MediaQuery.sizeOf(context).width - padding,
+      );
+    return appBarSize + padding + textPainter.height;
   }
 }

--- a/packages/app/features/session/lib/src/ui/session_page.dart
+++ b/packages/app/features/session/lib/src/ui/session_page.dart
@@ -175,7 +175,7 @@ class SessionPage extends ConsumerWidget with SessionPageMixin {
 
 // MEMO(@chippy-ao): Widget に書くと邪魔なので、mixin に出しました
 mixin SessionPageMixin {
-  final appBarSize = AppBar().preferredSize.height;
+  final appBarSize = kToolbarHeight;
   final padding = 16;
 
   /// title の長さに応じて、SliverAppBar の expandedHeight を計算します

--- a/packages/app/features/session/lib/src/ui/session_page.dart
+++ b/packages/app/features/session/lib/src/ui/session_page.dart
@@ -14,10 +14,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' as intl;
 
-final _dateFormatter = DateFormat.Md();
-final _timeFormatter = DateFormat.Hm();
+final _dateFormatter = intl.DateFormat.Md();
+final _timeFormatter = intl.DateFormat.Hm();
 
 class SessionPage extends ConsumerWidget {
   const SessionPage({


### PR DESCRIPTION
## Issue

- Closes #480 

## 説明

<!--
必ず書いてください。
やったことをわかりやすく短く書いてください。
-->

- TextPainter を使用して、動的にサイズを取るようにしました。
- TextPainter 使用時に TextDirection が intl と競合したため、import に as intl として競合解決しました。

## 画像 / 動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->
| Before | After | Design |
|-|-|-|
|<img src="https://github.com/user-attachments/assets/861da199-994f-4f0b-afb8-c83edb5b564c" width="300" /> | <img src="https://github.com/user-attachments/assets/938267f2-8e71-4c69-9e3b-360a20dc012b" width="300" />| |
|<img src="https://github.com/user-attachments/assets/850ab72a-c244-4a68-a566-94d864a9d77c" width="300" /> | <img src="https://github.com/user-attachments/assets/098046c4-a5a1-456a-beb8-9ee31c13455f" width="300" />| |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->

- TextSpan での textStyle ですが、SliverAppBar.large と SliverAppBar.medium でのデフォルトがこれだろうと半ば強引に決めうちでやっています。
-  お作法的な問題がなく、better であればマージしていただき、より良いものがあれば、別途ご対応お願いいたします。
