### PR TITLE
[app] お知らせ一覧画面：有効なお知らせのみを表示する

### DIFF
--- a/packages/app/features/news/lib/src/ui/news_page.dart
+++ b/packages/app/features/news/lib/src/ui/news_page.dart
@@ -31,14 +31,15 @@ class NewsPage extends HookConsumerWidget {
       ),
       body: newsAsyncValue.when(
         data: (newsList) {
-          return newsList.isNotEmpty
+          final availableNewsList = newsList.onlyAvailables();
+          return availableNewsList.isNotEmpty
               ? CustomScrollView(
                   slivers: [
                     SliverList(
                       delegate: SliverChildBuilderDelegate(
-                        childCount: newsList.length,
+                        childCount: availableNewsList.length,
                         (context, index) {
-                          final news = newsList[index];
+                          final news = availableNewsList[index];
                           return NewsListItem(
                             name: news.text,
                             publishedAt: news.startedAt,
@@ -65,5 +66,25 @@ class NewsPage extends HookConsumerWidget {
         },
       ),
     );
+  }
+}
+
+extension on List<News> {
+  /// 有効なお知らせのみに絞り込む
+  List<News> onlyAvailables() => where(
+        (news) => news.isAvailable,
+      ).toList();
+}
+
+extension on News {
+  /// 有効なお知らせかどうか
+  ///
+  /// 以下の２つの条件を満たす場合に有効と判断する。
+  /// ・お知らせがすでに始まっている（開始時刻が現在より前）。
+  /// ・お知らせがまだ終了していない（終了時刻が現在より後、もしくは終了時刻が指定されていない）。
+  bool get isAvailable {
+    final now = DateTime.now();
+    return startedAt.isBefore(now) &&
+        (endedAt == null || endedAt!.isAfter(now));
   }
 }


### PR DESCRIPTION
## Issue

- Closes #381

## 説明
お知らせ一覧画面で有効なお知らせのみを表示するようにしました。
有効かどうかの条件は、Issue #381 に書かれているとおりです。

> 有効であるためには、以下の2つの条件を満たしている必要があります:
> 
> * ニュースがすでに始まっている（開始時刻が現在より前）。
> * ニュースがまだ終了していない（終了時刻が現在より後、もしくは終了時刻が指定されていない）。

お知らせは `NewsRepository.getNews()` → `newsProvider` という経路でDB上のすべてのお知らせが返ってくるようでしたので、`NewsPage` の方でフィルタリングするようにしました。

できればもっと上流のところ（DBへのクエリなど）でフィルタリングしたいところですが、それらは common 配下にあり他にも影響しそうでしたので、一旦局所的な対応までとしております。

## 画像 / 動画
見た目の変更はないですが、意図したとおり絞り込まれた結果の画面を添付します。
次のようなお知らせのリストを `newsProvider` から返すようにして確認しました。

```dart
[
    News(
      id: 1,
      text: '掲載終了しているお知らせ',
      url: Uri.parse('https://example.com'),
      startedAt: DateTime(2024, 4),
      endedAt: DateTime(2024, 10),
    ),
    News(
      id: 2,
      text: '掲載中のお知らせ（終了日あり）',
      url: Uri.parse('https://example.com'),
      startedAt: DateTime(2024, 10),
      endedAt: DateTime(2024, 12),
    ),
    News(
      id: 3,
      text: '掲載中のお知らせ（終了日なし）',
      url: Uri.parse('https://example.com'),
      startedAt: DateTime(2024, 11),
      endedAt: null,
    ),
    News(
      id: 4,
      text: '掲載開始前のお知らせ（終了日あり）',
      url: Uri.parse('https://example.com'),
      startedAt: DateTime(2024, 11, 10),
      endedAt: DateTime(2024, 12, 10),
    ),
    News(
      id: 15
      text: '掲載開始前のお知らせ（終了日なし）',
      url: Uri.parse('https://example.com'),
      startedAt: DateTime(2024, 12),
      endedAt: null,
    ),
  ];
```

| Before | After |
|-|-|
| <img src="https://github.com/user-attachments/assets/161e6181-567c-4d4d-b21d-6668df638a5d" width="300" /> |<img src="https://github.com/user-attachments/assets/60458475-698d-4fca-8dc7-176e2629b9f2" width="300" /> | 

## その他
### お知らせ or ニュース
リポジトリ内で「お知らせ」と「ニュース」の表記揺れがあります。
検索したところ「お知らせ」がほとんどでしたのでコード中のコメントはそちらにあわせました。
「ニュース」としているのは [apps/app/README.md/L54](https://github.com/FlutterKaigi/2024/blob/4f40ef8b6e19d20635c082ec3c35bfd7e045b62f/apps/app/README.md?plain=1#L54) のみです。

### 仕様の疑問点（細かいですが...）
> * ニュースがすでに始まっている（開始時刻が現在より前）。

お知らせの開始日時が現在とぴったり一致した場合もお知らせは表示するものだと思いますので、「開始時刻が現在と同じ、もしくは、現在より前」がより厳密になります。

### さらなる改善案
> できればもっと上流のところ（DBへのクエリなど）でフィルタリングしたいところですが、

基本的にユーザー向けには有効なお知らせしか表示しないと思うので、この対応ができるともっと良いかなと思います。
フィルタリングのテストコードも書きやすくなります。

### NewsRepositoryでフィルタリング
DBへのクエリの時点でフィルタリングできれば、クライアントへの転送量も最小限に済む。以下はコードのイメージで、動作確認まではしていません。
```dart
  /// 有効なお知らせを取得する
  @override
  Future<List<News>> getAvaibaleNews() async {
    final now = DateTime.now().toIso8601String();
    final result = await _supabaseClient
        .from('news')
        .select()
        .lt('started_at', now)
        .or('ended_at.is.null,ended_at.gt.$now')
        .order('started_at', ascending: false)
        .withConverter(
          (json) => json.map(NewsTable.fromJson).toList(),
        );
    ...
```

### newsProviderでフィルタリング
`newsProvider`を`watch`して有効なお知らせのみを返す `availableNewsProvider` を用意する。以下はコードのイメージで、動作確認まではしていません。
```dart
@riverpod
Future<List<News>> availableNews(Ref ref) async {
  final newsList = await ref.watch(newsProvider.future);
  final now = DateTime.now();
  return newsList.where(
    (news) => news.startedAt.isBefore(now) && (news.endedAt == null || news.endedAt!.isAfter(now)),
  );
}
```

