### PR TITLE
[app] About画面のGitHubアイコンのタップでリポジトリを開く

### DIFF
--- a/packages/app/cores/core/lib/src/constants/official_social_urls.dart
+++ b/packages/app/cores/core/lib/src/constants/official_social_urls.dart
@@ -1,5 +1,5 @@
 class OfficialSocialUrls {
   static const medium = 'https://medium.com/flutterkaigi';
   static const x = 'https://x.com/FlutterKaigi';
-  static const github = 'https://github.com/FlutterKaigi/2024';
+  static const github = 'https://github.com/FlutterKaigi';
 }

--- a/packages/app/cores/core/lib/src/constants/official_social_urls.dart
+++ b/packages/app/cores/core/lib/src/constants/official_social_urls.dart
@@ -1,4 +1,5 @@
 class OfficialSocialUrls {
   static const medium = 'https://medium.com/flutterkaigi';
   static const x = 'https://x.com/FlutterKaigi';
+  static const github = 'https://github.com/FlutterKaigi/2024';
 }

--- a/packages/app/features/about/lib/src/ui/about_page.dart
+++ b/packages/app/features/about/lib/src/ui/about_page.dart
@@ -226,13 +226,14 @@ class AboutPage extends ConsumerWidget {
                       child: const MediumLogo(),
                     ),
                     const SizedBox(width: 8),
-                    IconButton(
-                      icon: const GithubLogo(),
-                      onPressed: () async {
+                    InkWell(
+                      onTap: () async {
                         await launchInExternalApp(
                           Uri.parse(OfficialSocialUrls.github),
                         );
                       },
+                      customBorder: const CircleBorder(),
+                      child: const GithubLogo(),
                     ),
                   ],
                 ),

--- a/packages/app/features/about/lib/src/ui/about_page.dart
+++ b/packages/app/features/about/lib/src/ui/about_page.dart
@@ -228,7 +228,11 @@ class AboutPage extends ConsumerWidget {
                     const SizedBox(width: 8),
                     IconButton(
                       icon: const GithubLogo(),
-                      onPressed: () async {},
+                      onPressed: () async {
+                        await launchInExternalApp(
+                          Uri.parse(OfficialSocialUrls.github),
+                        );
+                      },
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Issue

- Closes #415

## 説明

- About画面のGitHubアイコンのタップでリポジトリを開く
- Githubアプリインストール時はアプリで開き、未インストールの場合はWebブラウザで開きます。

## 画像 / 動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

|- | ブラウザで開く場合 | アプリで開く場合 |
|-|-|-|
| | <video src="https://github.com/user-attachments/assets/0c9c6b32-340d-4039-a3ea-8db64e119bbc" width="300" > | <video src="https://github.com/user-attachments/assets/8b38f5a4-ec99-4c32-a772-3e76db80dd60" width="300" > |

## その他

よろしくお願いします！
