### PR TITLE
fix: sessions.sponsor_id に ON DELETE CASCADE オプションを適用

### DIFF
--- a/packages/common/data/supabase/migrations/20241110160000_alter_sessions_sponsor_id_on_delete.sql
+++ b/packages/common/data/supabase/migrations/20241110160000_alter_sessions_sponsor_id_on_delete.sql
@@ -1,0 +1,5 @@
+ALTER TABLE sessions
+DROP CONSTRAINT sessions_sponsor_id_fkey;
+
+ALTER TABLE sessions
+ADD CONSTRAINT sessions_sponsor_id_fkey FOREIGN key (sponsor_id) REFERENCES sponsors (id) ON DELETE cascade;


### PR DESCRIPTION
## Issue

なし

## 説明

データベースのテストを実行したらエラーになってしまっていました。
原因は、sponsors テーブルのテストでレコードを削除しようとした時に session テーブルから sponsor_id として参照があったためでした。

つまり、親テーブル（sponsors）のレコードを削除しようとしたが、子テーブル（sessions）でまだそのレコードが使用されていたため、でした。

ですので、 `sessions.sponsor_id` の外部キー制約を削除してから `ON DELETE CASCADE` オプションを適用した外部キー制約を新たに追加することで対応しました。

## 画像 / 動画

テスト実行して成功したことを確認して、データや外部キー制約も意図した通りに設定されていそうでした。

<img width="721" alt="スクリーンショット 2024-11-10 17 25 27" src="https://github.com/user-attachments/assets/545a064e-e33b-462a-a99d-e6df86ac6ba2">

![image](https://github.com/user-attachments/assets/ed2cd0c9-4a30-4d04-b9b8-ec49f3fa30ae)

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
