### PR TITLE
[Data] feat: アプリの最小バージョンを管理するテーブルを作成

### DIFF
--- a/packages/common/data/supabase/migrations/20241110162100_add_semver_components.sql
+++ b/packages/common/data/supabase/migrations/20241110162100_add_semver_components.sql
@@ -1,0 +1,48 @@
+CREATE TYPE semver_components AS (major int, minor int, patch int, pre_release TEXT[], build_metadata TEXT[]);
+
+CREATE
+OR REPLACE function semver_elements_match_regex (parts TEXT[], regex text) returns bool language sql AS $$
+    -- validates that *parts* nullable array of non-empty strings
+    -- where each element of *parts* matches *regex*
+    select
+        $1 is null
+        or (
+            (
+                select (
+                    bool_and(pr_arr.elem is not null)
+                    and bool_and(pr_arr.elem ~ $2)
+                )
+                from
+                    unnest($1) pr_arr(elem)
+            )
+            and array_length($1, 1) > 0
+        )
+$$;
+
+CREATE DOMAIN semver AS semver_components CHECK (
+    -- major: non-null positive integer
+    (value).major IS NOT NULL
+    AND (value).major >= 0
+    -- minor: non-null positive integer
+    AND (value).minor IS NOT NULL
+    AND (value).minor >= 0
+    -- patch: non-null positive integer
+    AND (value).patch IS NOT NULL
+    AND (value).patch >= 0
+    AND semver_elements_match_regex ((value).pre_release, '^[A-z0-9]{1,255}$')
+    AND semver_elements_match_regex ((value).build_metadata, '^[A-z0-9\.]{1,255}$')
+);
+
+CREATE
+OR REPLACE function semver_to_text (semver) returns text immutable language sql AS $$
+    select
+        format('%s.%s.%s', $1.major, $1.minor, $1.patch)
+        || case
+            when $1.pre_release is null then ''
+            else format('-%s', array_to_string($1.pre_release, '.'))
+        end
+        || case
+            when $1.build_metadata is null then ''
+            else format('+%s', array_to_string($1.build_metadata, '.'))
+        end
+$$;

--- a/packages/common/data/supabase/migrations/20241110163100_add_app_version_table.sql
+++ b/packages/common/data/supabase/migrations/20241110163100_add_app_version_table.sql
@@ -6,6 +6,7 @@ CREATE TABLE public.app_minimum_versions (
     platform platform_type NOT NULL,
     app_version semver NOT NULL,
     app_version_text text generated always AS (semver_to_text (app_version)) stored,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     UNIQUE (platform, app_version_text)
 );
 

--- a/packages/common/data/supabase/migrations/20241110163100_add_app_version_table.sql
+++ b/packages/common/data/supabase/migrations/20241110163100_add_app_version_table.sql
@@ -1,0 +1,21 @@
+CREATE TYPE platform_type AS enum('android', 'ios');
+
+-- アプリの最小バージョンを管理するテーブル
+CREATE TABLE public.app_minimum_versions (
+    id smallserial PRIMARY KEY NOT NULL,
+    platform platform_type NOT NULL,
+    app_version semver NOT NULL,
+    app_version_text text generated always AS (semver_to_text (app_version)) stored,
+    UNIQUE (platform, app_version_text)
+);
+
+-- RLSを有効化
+ALTER TABLE app_minimum_versions enable ROW level security;
+
+-- 誰でも読み取り可能
+CREATE POLICY "Everyone can read app_minimum_versions" ON app_minimum_versions FOR
+SELECT
+    USING (TRUE);
+
+-- 管理者のみCRUD可能
+CREATE POLICY "Admin can CRUD app_minimum_versions" ON app_minimum_versions FOR ALL TO authenticated USING (role () = 'admin');

--- a/packages/common/data/supabase/tests/app_minimum_versions_test.sql
+++ b/packages/common/data/supabase/tests/app_minimum_versions_test.sql
@@ -1,0 +1,157 @@
+BEGIN;
+
+SELECT
+    dbdev.install ('basejump-supabase_test_helpers');
+
+CREATE EXTENSION "basejump-supabase_test_helpers"
+WITH
+    schema extensions;
+
+-- 事前準備: テストデータを削除
+DELETE FROM app_minimum_versions;
+
+-- 事前準備: テストデータを追加
+INSERT INTO
+    app_minimum_versions (platform, app_version)
+VALUES
+    ('android', (1, 0, 0, NULL, NULL)),
+    ('ios', (1, 0, 0, NULL, NULL));
+
+-- 管理者ユーザを作成
+SELECT
+    tests.create_supabase_user ('admin_user', 'admin@example.com', '555-555-5555');
+
+UPDATE profiles
+SET
+    name = 'admin_user',
+    role = 'admin'
+WHERE
+    id = (
+        SELECT
+            id
+        FROM
+            auth.users
+        WHERE
+            email = 'admin@example.com'
+    );
+
+-- 一般ユーザを作成
+SELECT
+    tests.create_supabase_user ('normal_user', 'user@example.com', '555-555-5556');
+
+UPDATE profiles
+SET
+    name = 'normal_user',
+    role = 'user'
+WHERE
+    id = (
+        SELECT
+            id
+        FROM
+            auth.users
+        WHERE
+            email = 'user@example.com'
+    );
+
+SELECT
+    plan (9);
+
+-- テーブルの存在確認
+SELECT
+    has_table ('public', 'app_minimum_versions', 'app_minimum_versions テーブルが存在すること');
+
+-- RLSが有効になっていることを確認
+SELECT
+    tests.rls_enabled ('public', 'app_minimum_versions');
+
+-- 一般ユーザーとして認証
+SELECT
+    tests.authenticate_as ('normal_user');
+
+-- 一般ユーザーは読み取りのみ可能
+SELECT
+    results_eq ('SELECT COUNT(*) FROM app_minimum_versions', ARRAY[2::bigint], '一般ユーザーはapp_minimum_versionsを読み取れること');
+
+-- 一般ユーザーは追加不可
+PREPARE insert_throw AS
+INSERT INTO
+    app_minimum_versions (platform, app_version)
+VALUES
+    ('android', (1, 1, 0, NULL, NULL));
+
+SELECT
+    throws_ok (
+        'insert_throw',
+        '42501',
+        'new row violates row-level security policy for table "app_minimum_versions"',
+        '一般ユーザーはapp_minimum_versionsを追加できないこと'
+    );
+
+-- 一般ユーザーは更新不可
+PREPARE update_throw AS
+UPDATE app_minimum_versions
+SET
+    app_version = (1, 1, 0, NULL, NULL)
+WHERE
+    platform = 'android'
+    AND app_version_text = '1.0.0';
+
+SELECT
+    results_eq (
+        'SELECT app_version_text FROM app_minimum_versions WHERE platform = ''android'' ORDER BY app_version_text DESC LIMIT 1',
+        ARRAY['1.0.0'],
+        '一般ユーザーはapp_minimum_versionsを更新できないこと'
+    );
+
+-- 一般ユーザーは削除不可
+PREPARE delete_throw AS
+DELETE FROM app_minimum_versions
+WHERE
+    platform = 'android';
+
+SELECT
+    results_eq ('SELECT COUNT(*) FROM app_minimum_versions', ARRAY[2::bigint], '一般ユーザーはapp_minimum_versionsを削除できないこと');
+
+-- 管理者として認証
+SELECT
+    tests.authenticate_as ('admin_user');
+
+-- 管理者は追加可能
+INSERT INTO
+    app_minimum_versions (platform, app_version)
+VALUES
+    ('android', (1, 1, 0, NULL, NULL));
+
+SELECT
+    results_eq ('SELECT COUNT(*) FROM app_minimum_versions', ARRAY[3::bigint], '管理者はapp_minimum_versionsを追加できること');
+
+-- 管理者は更新可能
+UPDATE app_minimum_versions
+SET
+    app_version = (1, 2, 0, NULL, NULL)
+WHERE
+    platform = 'android'
+    AND app_version_text = '1.1.0';
+
+SELECT
+    results_eq (
+        'SELECT app_version_text FROM app_minimum_versions WHERE platform = ''android'' ORDER BY app_version_text DESC LIMIT 1',
+        ARRAY['1.2.0'],
+        '管理者はapp_minimum_versionsを更新できること'
+    );
+
+-- 管理者は削除可能
+DELETE FROM app_minimum_versions
+WHERE
+    platform = 'android'
+    AND app_version_text = '1.2.0';
+
+SELECT
+    results_eq ('SELECT COUNT(*) FROM app_minimum_versions', ARRAY[2::bigint], '管理者はapp_minimum_versionsを削除できること');
+
+SELECT
+    *
+FROM
+    finish ();
+
+ROLLBACK;

--- a/packages/common/data/supabase/tests/semver_components_test.sql
+++ b/packages/common/data/supabase/tests/semver_components_test.sql
@@ -1,0 +1,47 @@
+BEGIN;
+
+SELECT
+    dbdev.install ('basejump-supabase_test_helpers');
+
+CREATE EXTENSION "basejump-supabase_test_helpers"
+WITH
+    schema extensions;
+
+-- semverカラムを持つテーブル
+CREATE TABLE package_version (
+    id bigserial PRIMARY KEY,
+    package_name text NOT NULL,
+    package_semver semver NOT NULL -- semverカラム
+);
+
+SELECT
+    plan (2);
+
+-- 有効なレコードを追加
+INSERT INTO
+    package_version (package_name, package_semver)
+VALUES
+    ('supabase-js', (2, 2, 3, NULL, NULL)),
+    ('supabase-js', (2, 0, 0, ARRAY['rc', '1'], NULL));
+
+SELECT
+    results_eq ('SELECT COUNT(*) FROM package_version', ARRAY[2::bigint], 'パッケージバージョンが2つあること');
+
+-- 無効なレコードを追加しようとする (majorがnull)
+SELECT
+    throws_ok (
+        $$ 
+        INSERT INTO package_version (package_name, package_semver)
+        VALUES ('invalid-js', (NULL, 1, 0, ARRAY['asdf'], NULL))
+        $$,
+        '23514',
+        'value for domain semver violates check constraint "semver_check"',
+        'パッケージバージョンを追加できないこと'
+    );
+
+SELECT
+    *
+FROM
+    finish ();
+
+ROLLBACK;


### PR DESCRIPTION
## Issue

#459 

## 説明

アプリの強制バージョンアップ機能のために、雑にアプリの最低バージョンを保持しておくテーブルを作成してみました。

- １つのレコードだけで運用していこうかなとも思ったのですが、運用記録が残るように複数レコード前提として設計してみました。
- 基本的に Android, iOS で同じバージョンになると思ったのですが、異なるバージョンの可能性もあるのでレコード分けてより安全に運用できるようにしてみました。

アプリでの実装は別のプルリクエストに分けて提出するので、詳しい仕様のすり合わせはそこでレビューいただければと思います。

## 画像 / 動画

意図通りに動作していそうです。

<img width="1610" alt="image" src="https://github.com/user-attachments/assets/c0a81af9-59fa-450b-a8f0-2558aee0e2d0">

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
