### PR TITLE
[App]: セッションをカレンダーに予定登録

### DIFF
--- a/packages/app/features/session/lib/src/ui/session_page.dart
+++ b/packages/app/features/session/lib/src/ui/session_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:add_2_calendar/add_2_calendar.dart';
 import 'package:app_cores_core/util.dart';
 import 'package:app_features_session/l10n.dart';
 import 'package:app_features_session/src/data/model/timeline_item.dart';
@@ -18,6 +19,7 @@ import 'package:intl/intl.dart' as intl;
 
 final _dateFormatter = intl.DateFormat.Md();
 final _timeFormatter = intl.DateFormat.Hm();
+final _googleCalendarDateFormatter = intl.DateFormat("yyyyMMdd'T'HHmmss'Z'");
 
 class SessionPage extends ConsumerWidget with SessionPageMixin {
   SessionPage({
@@ -141,8 +143,20 @@ class SessionPage extends ConsumerWidget with SessionPageMixin {
                       style: Theme.of(context).textTheme.bodyLarge,
                     ),
                     leading: const Icon(Icons.event_outlined),
-                    onTap: () {
-                      // TODO: 該当の日時でカレンダーを開く (#24)
+                    onTap: () async {
+                      switch (defaultTargetPlatform) {
+                        case TargetPlatform.iOS:
+                          final event = _createIosEvent(session);
+                          await Add2Calendar.addEvent2Cal(event);
+                        case TargetPlatform.macOS:
+                        case TargetPlatform.android:
+                        case TargetPlatform.fuchsia:
+                        case TargetPlatform.linux:
+                        case TargetPlatform.windows:
+                          await launchInExternalApp(
+                            _createGoogleCalendarUrl(session),
+                          );
+                      }
                     },
                   ),
                 ),
@@ -208,4 +222,35 @@ mixin SessionPageMixin {
       );
     return appBarSize + padding + textPainter.height;
   }
+}
+
+Event _createIosEvent(
+  TimelineItemSession session,
+) =>
+    Event(
+      title: 'FlutterKaigi 2024: ${session.title}',
+      description: session.description,
+      location: session.venue.name,
+      startDate: session.startsAt,
+      endDate: session.endsAt,
+      iosParams: const IOSParams(
+        reminder: Duration(minutes: 10),
+      ),
+    );
+
+Uri _createGoogleCalendarUrl(
+  TimelineItemSession session,
+) {
+  return Uri.https(
+    'www.google.com',
+    'calendar/render',
+    {
+      'action': 'TEMPLATE',
+      'text': 'FlutterKaigi 2024: ${session.title}',
+      'details': session.description,
+      'location': session.venue.name,
+      'dates':
+          '${_googleCalendarDateFormatter.format(session.startsAt.toUtc())}/${_googleCalendarDateFormatter.format(session.endsAt.toUtc())}',
+    },
+  );
 }

--- a/packages/app/features/session/pubspec.lock
+++ b/packages/app/features/session/pubspec.lock
@@ -14,6 +14,14 @@ packages:
     description: dart
     source: sdk
     version: "0.3.2"
+  add_2_calendar:
+    dependency: "direct main"
+    description:
+      name: add_2_calendar
+      sha256: "8d7a82aba607d35f2a5bc913419e12f865a96a350a8ad2509a59322bc161f200"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   analyzer:
     dependency: transitive
     description:

--- a/packages/app/features/session/pubspec.yaml
+++ b/packages/app/features/session/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: ^3.26.0-0.1.pre
 
 dependencies:
+  add_2_calendar: ^3.0.1
   app_cores_core:
     path: ../../cores/core
   app_cores_designsystem:


### PR DESCRIPTION
## Issue

- Closes #24

## 説明

<!--
必ず書いてください。
やったことをわかりやすく短く書いてください。
-->

- セッション詳細画面の日時をタップしたとき、カレンダーアプリへ予定を登録できる機能を追加

## 画像 / 動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
|-|-|-|
| | | |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
