### PR TITLE
[website_api]: SpecialSponsorのOGP生成に対応

### DIFF
--- a/apis/supabase-types/src/types/index.ts
+++ b/apis/supabase-types/src/types/index.ts
@@ -644,6 +644,7 @@ export type Database = {
           description: string | null
           id: number | null
           logo_name: string | null
+          name: string | null
           sessions: Json | null
           sort_id: number | null
           type: string | null
@@ -656,6 +657,7 @@ export type Database = {
           description: string | null
           id: number | null
           logo_name: string | null
+          name: string | null
           sort_id: number | null
           type: string | null
           url: string | null

--- a/apis/website-html-rewriter/src/ogImage.tsx
+++ b/apis/website-html-rewriter/src/ogImage.tsx
@@ -362,7 +362,7 @@ async function getSponsorHtml({
 	}
 
 	const sponsorImageUrl = await supabase.storage
-		.from("sponsor")
+		.from("sponsors")
 		.getPublicUrl(data.logo_name.replaceAll(".webp", ".png"));
 
 	const sponsorTypeLogoUrl = new URL(

--- a/apis/website-html-rewriter/src/ogImage.tsx
+++ b/apis/website-html-rewriter/src/ogImage.tsx
@@ -347,7 +347,7 @@ async function getSponsorHtml({
 	url: URL;
 }): Promise<JSX.Element> {
 	const { data, error } = await supabase
-		.from("sponsors")
+		.from("sponsors_v2")
 		.select("*")
 		.eq("id", id)
 		.maybeSingle();
@@ -356,6 +356,9 @@ async function getSponsorHtml({
 	}
 	if (!data) {
 		return <div>Sponsor not found</div>;
+	}
+	if (!data.logo_name) {
+		throw new Error("Logo name is not found");
 	}
 
 	const sponsorImageUrl = await supabase.storage

--- a/apis/website-html-rewriter/src/server.ts
+++ b/apis/website-html-rewriter/src/server.ts
@@ -45,7 +45,7 @@ app.get(
 			c.env.SUPABASE_KEY,
 		);
 		const { data, error } = await supabase
-			.from("sponsors")
+			.from("sponsors_v2")
 			.select()
 			.eq("id", id)
 			.maybeSingle();
@@ -54,6 +54,12 @@ app.get(
 		}
 		if (!data) {
 			return c.json({ error: "Sponsor not found" }, 404);
+		}
+		if (!data.name) {
+			return c.json({ error: "Name is not found" }, 404);
+		}
+		if (!data.logo_name) {
+			return c.json({ error: "Logo name is not found" }, 404);
 		}
 
 		const url = new URL(c.req.url);


### PR DESCRIPTION
> [!NOTE]
> - #496 をマージしてください

## 説明

- SpecialSponsorのOG生成に対応しました
  - 具体的には、Cloudflare Workersがスポンサー情報を取ってくる時に`sponsor`テーブルではなく `sponsor_v2`ビューを使うようにしました


## めも

- [x] Staging, Production環境に画像を配置済み

## 画像 / 動画


### OG Image (Debug)
| DroidKaigi | Pocketalk|
| - | - |
|![image](https://github.com/user-attachments/assets/cd30e8a6-0bf8-4849-b0ff-9ddfa1308f39)|![image](https://github.com/user-attachments/assets/09040be3-88e4-40ca-894e-8eef613e7e0a)|


### OG
https://flutterkaigi.slack.com/archives/C06T5TXN19R/p1731348837612229?thread_ts=1731342321.703459&cid=C06T5TXN19R
![image](https://github.com/user-attachments/assets/2ef9f663-4d7f-4da4-8353-257161287384)

