### PR TITLE
#491 [app] Day 1 と Day 2 のスクロール位置が同期されてしまっている

### DIFF
--- a/packages/app/features/session/lib/src/data/model/session_date.dart
+++ b/packages/app/features/session/lib/src/data/model/session_date.dart
@@ -16,4 +16,6 @@ enum SessionDate {
     }
     return null;
   }
+
+  bool get isDay1 => this == day1;
 }


### PR DESCRIPTION
## Issue

- Closes #491 

## 説明

<!--
必ず書いてください。
やったことをわかりやすく短く書いてください。
-->
- セッション一覧画面でのDay1とDay2の`ScrollController`や`Widget`が同等のものを利用していたため、Widget自体は同等のものを利用する様にし、`ScrollController` / `PageStorageKey`を独立したものを利用する様にし、スクロールを独立させました。

## 画像 / 動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After |
|-|-|
|　<video src="https://github.com/user-attachments/assets/69791a38-affb-492e-9546-6261e14aab23" width="300" > | <video src="https://github.com/user-attachments/assets/039e4a4d-c052-4508-9a2d-ba1ef6bb2fce" width="300" > |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
[参考](https://api.flutter.dev/flutter/widgets/PageStorage-class.html)