### PR TITLE
[data] 個人スポンサーのプロフィールを返すViewのバグ修正

### DIFF
--- a/packages/common/data/supabase/migrations/20241112193700_alter_profiles_with_sns_for_individual_sponsor.sql
+++ b/packages/common/data/supabase/migrations/20241112193700_alter_profiles_with_sns_for_individual_sponsor.sql
@@ -2,14 +2,10 @@ DROP VIEW public.profiles_with_sns_for_individual_sponsor;
 
 CREATE VIEW public.profiles_with_sns_for_individual_sponsor AS
 SELECT
-  p.*,
-  json_agg(psns.*) AS sns_accounts
+  p.*
 FROM
-  public.profiles AS p
-  JOIN public.tickets AS t ON t.user_id = p.id
-  JOIN public.profile_social_networking_services AS psns ON psns.id = p.id
+  public.profiles_with_sns AS p
+  LEFT JOIN public.tickets AS t ON t.user_id = p.id
 WHERE
   t.type = 'individual_sponsor'::ticket_type
   AND p.is_published = TRUE
-GROUP BY
-  p.id;

--- a/packages/common/data/supabase/migrations/20241112193700_alter_profiles_with_sns_for_individual_sponsor.sql
+++ b/packages/common/data/supabase/migrations/20241112193700_alter_profiles_with_sns_for_individual_sponsor.sql
@@ -1,0 +1,15 @@
+DROP VIEW public.profiles_with_sns_for_individual_sponsor;
+
+CREATE VIEW public.profiles_with_sns_for_individual_sponsor AS
+SELECT
+  p.*,
+  json_agg(psns.*) AS sns_accounts
+FROM
+  public.profiles AS p
+  JOIN public.tickets AS t ON t.user_id = p.id
+  JOIN public.profile_social_networking_services AS psns ON psns.id = p.id
+WHERE
+  t.type = 'individual_sponsor'::ticket_type
+  AND p.is_published = TRUE
+GROUP BY
+  p.id;


### PR DESCRIPTION
## 説明

- 個人スポンサーの一覧を返す`profiles_with_sns_for_individual_sponsor`viewですが、`profiles_with_sns`viewとレスポンスの型が異なっていたので `profiles_with_sns_for_individual_sponsor`側を統一しました
  - Dart側の型定義は既に統一されていました(`ProfileWithSns class`で表現されています)

