### PR TITLE
[All] melos.yaml の公式スキーマを参照する

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,8 @@
     "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
   },
   "yaml.schemas": {
-    "https://json.schemastore.org/github-issue-config.json": ".github/ISSUE_TEMPLATE/config.yaml"
+    "https://json.schemastore.org/github-issue-config.json": ".github/ISSUE_TEMPLATE/config.yaml",
+    "https://raw.githubusercontent.com/invertase/melos/main/melos.yaml.schema.json": "melos.yaml"
   },
   "[sql]": {
     "editor.defaultFormatter": "ReneSaarsoo.sql-formatter-vsc"


### PR DESCRIPTION
## Issue

- Closes #409

## 説明

melos.yamlのSchemaチェックの追加、および動作確認を行いました。

## 画像 / 動画

以下のように、YAML拡張を追加したVSCodeを使用していると、schemeに沿わない書き方の場合にエラーが出ます

<img src="https://github.com/user-attachments/assets/496353d9-9dcf-41a8-981f-cc70596dd847" width="500" />


## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->


(ただの感想ですが) runとexecが両方書いてあった場合もエラー出してほしいなと思いました..

<img src="https://github.com/user-attachments/assets/7a270ccf-f6ed-4af2-ae4b-6c5150c69591" width="300" />