### PR TITLE
[ticket_web](fix): 環境変数のBaseURLでは 末尾のスラッシュを削除

### DIFF
--- a/apps/ticket_web/defines/production.env
+++ b/apps/ticket_web/defines/production.env
@@ -5,6 +5,6 @@ STRIPE_PAYMENT_GENERAL_URL=https://buy.stripe.com/00g5kmd4A6UL54A5kq
 STRIPE_PAYMENT_INVITATION_URL=https://buy.stripe.com/00geUW0hOenddB6cMU
 STRIPE_PAYMENT_PERSONAL_SPONSOR_URL=https://buy.stripe.com/6oEfZ00hOdj954A3cj
 
-TICKET_API_BASE_URL=https://flutterkaigi-ticket-2024-api-production.flutter-kaigi.workers.dev/
+TICKET_API_BASE_URL=https://flutterkaigi-ticket-2024-api-production.flutter-kaigi.workers.dev
 
 ENVIRONMENT=PRODUCTION

--- a/apps/ticket_web/defines/staging.env.example
+++ b/apps/ticket_web/defines/staging.env.example
@@ -5,6 +5,6 @@ STRIPE_PAYMENT_GENERAL_URL=https://buy.stripe.com/test_28oaEV98iaZQ6PKdQQ
 STRIPE_PAYMENT_INVITATION_URL=https://buy.stripe.com/test_7sIdR7gAK0lc4HCeUV
 STRIPE_PAYMENT_PERSONAL_SPONSOR_URL=https://buy.stripe.com/test_28oaEV98iaZQ6PKdQQ
 
-TICKET_API_BASE_URL=https://flutterkaigi-ticket-2024-api-staging.flutter-kaigi.workers.dev/
+TICKET_API_BASE_URL=https://flutterkaigi-ticket-2024-api-staging.flutter-kaigi.workers.dev
 
 ENVIRONMENT=STAGING


### PR DESCRIPTION
## 説明

- 環境変数に格納している TicketAPIのBaseURLの末尾にスラッシュがついており、「ウォレットに追加」の遷移でNotFoundになっていた
  - 今までAPIを叩く時は Dioを用いていたため 正規化されており気が付かなかった

![image](https://github.com/user-attachments/assets/21ab320f-2626-4815-ac3d-f3346dbd9066)

![image](https://github.com/user-attachments/assets/f4f9ef0d-cdee-4d64-b335-0b1dbb876a21)
