### PR TITLE
[App] 左上に表示されるMainLogoにexcludeFromSemanticsパラメータを追加する

### DIFF
--- a/packages/app/cores/designsystem/lib/src/ui/main_logo.dart
+++ b/packages/app/cores/designsystem/lib/src/ui/main_logo.dart
@@ -18,10 +18,12 @@ class MainLogo extends StatelessWidget {
       Brightness.light => CommonAssets.logo.mainLogoLight.svg(
           width: size,
           height: size,
+          excludeFromSemantics: true,
         ),
       Brightness.dark => CommonAssets.logo.mainLogoDark.svg(
           width: size,
           height: size,
+          excludeFromSemantics: true,
         ),
     };
   }


### PR DESCRIPTION
## Issue

- Closes #383 

## 説明

<!--
必ず書いてください。
やったことをわかりやすく短く書いてください。
-->

`MainLogo` の画像に `excludeFromSemantics` を追加

## 画像 / 動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->

| Before | After | Design |
|-|-|-|
| <img src="https://github.com/user-attachments/assets/684bbb2c-e01f-417b-9fce-6b198e44ee62" width="300" /> | <img src="https://github.com/user-attachments/assets/2079fa48-cfba-4b78-8a45-39a80400527a" width="300" /> | |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
