### PR TITLE
About画面の各アイコンのエフェクトが反映される領域の調整

### DIFF
--- a/packages/app/features/about/lib/src/ui/about_page.dart
+++ b/packages/app/features/about/lib/src/ui/about_page.dart
@@ -213,9 +213,11 @@ class AboutPage extends ConsumerWidget {
                         );
                       },
                       customBorder: const CircleBorder(),
-                      child: const XLogo(),
+                      child: const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: XLogo(),
+                      ),
                     ),
-                    const SizedBox(width: 8),
                     InkWell(
                       onTap: () async {
                         await launchInExternalApp(
@@ -225,7 +227,6 @@ class AboutPage extends ConsumerWidget {
                       customBorder: const CircleBorder(),
                       child: const MediumLogo(),
                     ),
-                    const SizedBox(width: 8),
                     InkWell(
                       onTap: () async {
                         await launchInExternalApp(
@@ -233,7 +234,10 @@ class AboutPage extends ConsumerWidget {
                         );
                       },
                       customBorder: const CircleBorder(),
-                      child: const GithubLogo(),
+                      child: const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: GithubLogo(),
+                      ),
                     ),
                   ],
                 ),

--- a/packages/app/features/about/lib/src/ui/about_page.dart
+++ b/packages/app/features/about/lib/src/ui/about_page.dart
@@ -226,7 +226,10 @@ class AboutPage extends ConsumerWidget {
                         );
                       },
                       customBorder: const CircleBorder(),
-                      child: const MediumLogo(),
+                      child: const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: MediumLogo(),
+                      ),
                     ),
                     const SizedBox(width: 8),
                     InkWell(

--- a/packages/app/features/about/lib/src/ui/about_page.dart
+++ b/packages/app/features/about/lib/src/ui/about_page.dart
@@ -218,6 +218,7 @@ class AboutPage extends ConsumerWidget {
                         child: XLogo(),
                       ),
                     ),
+                    const SizedBox(width: 8),
                     InkWell(
                       onTap: () async {
                         await launchInExternalApp(
@@ -227,6 +228,7 @@ class AboutPage extends ConsumerWidget {
                       customBorder: const CircleBorder(),
                       child: const MediumLogo(),
                     ),
+                    const SizedBox(width: 8),
                     InkWell(
                       onTap: () async {
                         await launchInExternalApp(


### PR DESCRIPTION
## Issue

- Closes #482 

## 説明
- XとGithubのエフェクトが反映される範囲が小さかったため、Paddingを使用し、領域を広げてみました。
- Paddingを使用した分、SizedBoxの余白を削除することで、位置などについてはできるだけ変わらないようにしました。


## 画像 / 動画

<!--
見た目の変更があれば、画像や動画を添付してください。

<img src="" width="300" />
<video src="" width="300" >
-->






| Before | After | Design | Design |
|-|-|-|-|
| <img src="https://github.com/user-attachments/assets/c1f9c79a-3e28-4322-b053-5bc5bacb0b9c" width="300" />| <img src="https://github.com/user-attachments/assets/52cd10be-e975-482c-a0bd-c04e936159b7" width="300" /> | <img src="https://github.com/user-attachments/assets/9c039f4b-2a39-4f85-8a4c-1fbcd58e0a07" width="300" /> |<img src="https://github.com/user-attachments/assets/5119a2b7-8b89-47b7-aa2c-b335fecb75c9" width="300" />|




## その他
- 他に方法がありましたらコメントをいただけると幸いです

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
