### PR TITLE
[App] ci: App Store へデプロイ用のワークフローを仮作成

### DIFF
--- a/.github/workflows/deploy-app-ios.yaml
+++ b/.github/workflows/deploy-app-ios.yaml
@@ -1,0 +1,39 @@
+name: Deploy App iOS
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: environment
+        required: true
+        type: choice
+        options:
+          - "flutterkaigi-app-2024-development"
+          - "flutterkaigi-app-2024-production"
+
+permissions:
+  contents: read
+
+jobs:
+  check-environment:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Check Environment
+        run: |
+          # flutterkaigi-app-2024-development はまだ未対応
+          if [ "${{ github.event.inputs.environment }}" = "flutterkaigi-app-2024-development" ]; then
+            echo "flutterkaigi-app-2024-development is not supported yet"
+            exit 1
+          fi
+
+  deploy-app-ios:
+    needs: check-environment
+    runs-on: macos-14
+    environment: ${{ github.event.inputs.environment }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Demo
+        run: echo "Demo"

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -2,6 +2,7 @@
   "words": [
     "appbundle",
     "Ariake",
+    "codesign",
     "designsystem",
     "dorny",
     "Initilize",
@@ -24,6 +25,9 @@
     "textlint",
     "unawaited",
     "webp",
+    "xcarchive",
+    "xcodebuild",
+    "xcworkspace",
     "YumNumm",
     "zenn"
   ],

--- a/apps/app/.gitignore
+++ b/apps/app/.gitignore
@@ -48,3 +48,6 @@ app.*.map.json
 # Ignore these to use per-flavor files.
 ios/Runner/GoogleService-Info.plist
 android/app/google-services.json
+
+# App Store Connect related
+*.p8

--- a/apps/app/ios/Runner/ExportOptions.plist
+++ b/apps/app/ios/Runner/ExportOptions.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>compileBitcode</key>
+	<false/>
+	<key>destination</key>
+	<string>upload</string>
+	<key>manageAppVersionAndBuildNumber</key>
+	<true/>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>teamID</key>
+	<string>6JT949BA2M</string>
+	<key>uploadSymbols</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/app/ios/fastlane/Fastfile
+++ b/apps/app/ios/fastlane/Fastfile
@@ -1,0 +1,20 @@
+default_platform(:ios)
+
+platform :ios do
+  lane :deploy_appstore do
+    key_data = Base64.strict_decode64(ENV['KEY_BASE64'])
+    
+    app_store_connect_api_key(
+      key_id: ENV['KEY_ID'],
+      issuer_id: ENV['ISSUER_ID'],
+      key_content: key_data,
+    )
+
+    upload_to_app_store(
+      app_identifier: app_id,
+      api_key: api_key,
+      ipa: "../build/ios/ipa/Runner.ipa",
+      skip_waiting_for_build_processing: true,
+    )
+  end
+end

--- a/melos.yaml
+++ b/melos.yaml
@@ -79,6 +79,41 @@ scripts:
     exec: flutter build appbundle --dart-define-from-file=defines/production.env
     packageFilters:
       scope: conference_2024_app
+  adhoc:
+    exec: |
+      flutter build ipa --release \
+        --export-method=ad-hoc \
+        --dart-define-from-file=defines/production.env
+    packageFilters:
+      scope: conference_2024_app
+  app:build:ipa:production:
+    exec: |
+      # 署名なしでビルド
+      flutter build ios --release --no-codesign \
+        --dart-define-from-file=defines/production.env
+      # 署名なしで .xcarchive を作成
+      xcodebuild archive \
+        CODE_SIGNING_REQUIRED=NO \
+        CODE_SIGNING_ALLOWED=NO \
+        -workspace ./ios/Runner.xcworkspace \
+        -scheme Runner \
+        -configuration Release \
+        -archivePath ./build/ios/Runner.xcarchive
+      # Entitlements 情報を付与
+      # codesign --entitlements $ENTITLEMENTS_FILE_PATH \
+      #   -s $IDENTIFIER_TOKEN \
+      #   ./build/ios/Runner.xcarchive/Products/Applications/Runner.app
+      # 署名ありで .ipa を作成
+      xcodebuild -exportArchive \
+        -archivePath ./build/ios/Runner.xcarchive \
+        -exportPath ./build/ios/ipa \
+        -exportOptionsPlist ./ios/Runner/ExportOptions.plist \
+        -allowProvisioningUpdates \
+        -authenticationKeyID $APP_STORE_CONNECT_API_KEY_ID \
+        -authenticationKeyIssuerID $APP_STORE_CONNECT_API_KEY_ISSUER_ID \
+        -authenticationKeyPath $MELOS_ROOT_PATH/apps/app/private_keys/AuthKey_$APP_STORE_CONNECT_API_KEY_ID.p8
+    packageFilters:
+      scope: conference_2024_app
   pod:install:
     exec: cd ios && pod install
     packageFilters:

--- a/melos.yaml
+++ b/melos.yaml
@@ -79,13 +79,6 @@ scripts:
     exec: flutter build appbundle --dart-define-from-file=defines/production.env
     packageFilters:
       scope: conference_2024_app
-  adhoc:
-    exec: |
-      flutter build ipa --release \
-        --export-method=ad-hoc \
-        --dart-define-from-file=defines/production.env
-    packageFilters:
-      scope: conference_2024_app
   app:build:ipa:production:
     exec: |
       # 署名なしでビルド


### PR DESCRIPTION
## Issue

#439 

## 説明

App Store へデプロイ用のワークフローを仮作成しました。
処理とかも一旦適当に作成しています。

リリースブランチでデプロイの検証するため、ぱっと見おかしなことしていそうにないか確認して Approve いただければと思います 🙏 

## 画像 / 動画

特になし

## その他

- https://developer.apple.com/help/account/create-certificates/cloud-managed-certificates/
- https://zenn.dev/welchi/articles/flutter-ios-ci-cd-xcode-cloud
- https://zenn.dev/yorifuji/articles/build-automatically-manage-singin-on-ci
- https://qiita.com/arasan01/items/7521255be581ac451c4f
- https://cam-inc.co.jp/p/techblog/956439539012861954
- https://melos.invertase.dev/environment-variables

