### PR TITLE
[ticket-api] 返金APIを実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,5 +43,8 @@
   "SQL-Formatter-VSCode.keywordCase": "upper",
   "SQL-Formatter-VSCode.dataTypeCase": "lower",
   "SQL-Formatter-VSCode.functionCase": "lower",
-  "SQL-Formatter-VSCode.identifierCase": "lower"
+  "SQL-Formatter-VSCode.identifierCase": "lower",
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }

--- a/apis/ticket-api/package.json
+++ b/apis/ticket-api/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@hono-rate-limiter/cloudflare": "^0.2.1",
     "@hono/valibot-validator": "^0.3.1",
-    "@supabase/supabase-js": "^2.45.4",
-    "hono": "^4.6.5",
+    "@supabase/supabase-js": "^2.46.1",
+    "hono": "^4.6.10",
     "hono-rate-limiter": "^0.4.0",
     "passkit-generator": "^3.2.0",
     "stripe": "^16.12.0",
@@ -22,8 +22,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@cloudflare/workers-types": "^4.20241011.0",
+    "@cloudflare/workers-types": "^4.20241112.0",
     "configs": "workspace:*",
-    "wrangler": "^3.80.4"
+    "wrangler": "^3.87.0"
   }
 }

--- a/apis/ticket-api/src/routes/v1/payment.ts
+++ b/apis/ticket-api/src/routes/v1/payment.ts
@@ -49,7 +49,7 @@ app.get(
 		const results = payments.map((payment) => ({
 			payment_intent: payment.id,
 			amount: payment.amount,
-			created: payment.created,
+			created_at: new Date(payment.created * 1000).toISOString(),
 		}));
 		return c.json({ results });
 	},

--- a/apis/ticket-api/src/routes/v1/payment.ts
+++ b/apis/ticket-api/src/routes/v1/payment.ts
@@ -1,0 +1,198 @@
+import { vValidator } from "@hono/valibot-validator";
+import { createClient } from "@supabase/supabase-js";
+import { Hono } from "hono";
+import Stripe from "stripe";
+import type { Database } from "supabase-types";
+import * as v from "valibot";
+import type { Bindings } from "../../bindings";
+import { authorizationSchema } from "../../util/authorizationSchema";
+import { getUser, getUserWithProfile } from "../../util/user";
+
+const app = new Hono<{ Bindings: Bindings }>();
+
+app.get(
+	"/search",
+	vValidator(
+		"query",
+		v.object({
+			email: v.pipe(v.string(), v.email()),
+		}),
+	),
+	vValidator("header", authorizationSchema),
+	async (c) => {
+		const { email } = c.req.valid("query");
+		const { authorization } = c.req.valid("header");
+		const supabase = createClient<Database>(
+			c.env.SUPABASE_URL,
+			c.env.SUPABASE_KEY,
+		);
+		const invoker = await getUserWithProfile(authorization, supabase);
+		if (!invoker.success) {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+		if (invoker.profile.role !== "admin") {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+
+		const stripe = new Stripe(c.env.STRIPE_KEY);
+		const customers = await stripe.customers.search({
+			query: `email:\'${email}\'`,
+			limit: 100,
+		});
+		const payments = [];
+		for (const customer of customers.data) {
+			const paymentIntents = await stripe.paymentIntents.search({
+				query: `customer:\'${customer.id}\'`,
+			});
+			payments.push(...paymentIntents.data);
+		}
+		const results = payments.map((payment) => ({
+			payment_intent: payment.id,
+			amount: payment.amount,
+			created: payment.created,
+		}));
+		return c.json({ results });
+	},
+);
+
+app.post(
+	"/refund",
+	vValidator(
+		"query",
+		v.object({
+			payment_intent: v.string(),
+			user_id: v.string(),
+		}),
+	),
+	vValidator("header", authorizationSchema),
+	async (c) => {
+		const { authorization } = c.req.valid("header");
+		const { payment_intent, user_id } = c.req.valid("query");
+		const supabase = createClient<Database>(
+			c.env.SUPABASE_URL,
+			c.env.SUPABASE_KEY,
+		);
+		const invoker = await getUserWithProfile(authorization, supabase);
+		if (!invoker.success) {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+		if (invoker.profile.role !== "admin") {
+			return c.json({ error: "Unauthorized" }, 401);
+		}
+		const userResult = await supabase
+			.from("profiles")
+			.select("*")
+			.eq("id", user_id)
+			.single();
+		const user = await supabase.auth.admin.getUserById(user_id);
+		if (userResult.error || user.error) {
+			console.error(userResult.error, user.error);
+			return c.json({
+				error: userResult.error?.message || user.error?.message,
+			});
+		}
+		const stripe = new Stripe(c.env.STRIPE_KEY);
+		try {
+			const refund = await stripe.refunds.create({
+				payment_intent: payment_intent,
+				metadata: {
+					user_id,
+				},
+				reason: "requested_by_customer",
+			});
+
+			await fetch(c.env.SLACK_WEBHOOK_URL, {
+				method: "POST",
+				body: JSON.stringify({
+					text: `Refunded: ${payment_intent}`,
+					blocks: [
+						{
+							type: "header",
+							text: {
+								type: "plain_text",
+								text: "返金が実行されました",
+							},
+						},
+						{
+							type: "context",
+							elements: [
+								{
+									text: new Date().toLocaleString("ja-JP", {
+										timeZone: "Asia/Tokyo",
+									}),
+									type: "mrkdwn",
+								},
+							],
+						},
+						{
+							type: "divider",
+						},
+						{
+							type: "section",
+							text: {
+								type: "mrkdwn",
+								text: `Payment Intent: \`${payment_intent}\`\nUser ID: \`${user_id}\``,
+							},
+						},
+						{
+							type: "section",
+							text: {
+								type: "mrkdwn",
+								text: `UserName: ${userResult.data?.name}`,
+							},
+						},
+						{
+							type: "section",
+							text: {
+								type: "mrkdwn",
+								text: `Email: ${user.data?.user.email}`,
+							},
+						},
+						{
+							type: "context",
+							elements: [
+								{
+									text: "Notify: <@U059EJ5AVQR>",
+									type: "mrkdwn",
+								},
+							],
+						},
+						{
+							type: "context",
+							elements: [
+								{
+									text: `Invoker: ${invoker.profile.name}: ${invoker.user.id} ${invoker.user.email}`,
+									type: "mrkdwn",
+								},
+							],
+						},
+					],
+				}),
+			});
+			return c.json({ refund });
+		} catch (e) {
+			await fetch(c.env.SLACK_WEBHOOK_URL, {
+				method: "POST",
+				body: JSON.stringify({
+					text: `Error: ${e}`,
+					blocks: [
+						{
+							type: "header",
+							text: {
+								type: "plain_text",
+								text: "返金に失敗しました",
+							},
+						},
+					],
+				}),
+			});
+			if (e instanceof Stripe.errors.StripeInvalidRequestError) {
+				return c.json({ error: e.message });
+			}
+			console.error(e);
+			return c.json({ error: e });
+		}
+	},
+);
+
+export default app;

--- a/apis/ticket-api/src/routes/v1/payment.ts
+++ b/apis/ticket-api/src/routes/v1/payment.ts
@@ -169,7 +169,7 @@ app.post(
 					],
 				}),
 			});
-			return c.json({ refund });
+			return c.json({ refund: refund.id });
 		} catch (e) {
 			await fetch(c.env.SLACK_WEBHOOK_URL, {
 				method: "POST",

--- a/apis/ticket-api/src/routes/v1/v1.ts
+++ b/apis/ticket-api/src/routes/v1/v1.ts
@@ -12,11 +12,12 @@ import {
 } from "../../features/coupon/coupon";
 import { authorizationSchema } from "../../util/authorizationSchema";
 import { getUser, getUserWithProfile } from "../../util/user";
+import payment from "./payment";
 import wallet from "./wallet";
-
 const v1 = new Hono<{ Bindings: Bindings }>();
 
 v1.route("/wallet", wallet);
+v1.route("/payment", payment);
 
 const verifyPurchaseSchema = v.object({
 	stripe_session_id: v.string(),

--- a/apis/ticket-api/src/routes/v1/wallet.ts
+++ b/apis/ticket-api/src/routes/v1/wallet.ts
@@ -13,188 +13,187 @@ import { getUser, getUserWithProfile } from "../../util/user";
 
 const app = new Hono<{ Bindings: Bindings }>();
 
-app.get(
-	"/pass.pkpass",
-	vValidator("query", authorizationSchema),
-	async (c) => {
-		const supabase = createClient<Database>(
-			c.env.SUPABASE_URL,
-			c.env.SUPABASE_KEY,
-		);
-		const { authorization } = c.req.valid("query");
-		const user = await getUserWithProfile(authorization, supabase);
-		if (!user || !user.success) {
-			return c.json({ error: "Unauthorized" }, 401);
-		}
-		const { data: ticket, error } = await supabase
-			.from("tickets")
-			.select()
-			.eq("user_id", user.profile.id)
-			.maybeSingle();
-		if (error) {
-			return c.json({ error: "Internal Server Error" }, 500);
-		}
-		if (!ticket) {
-			return c.json({ error: "Ticket not found" }, 404);
-		}
+app.get("/pass.pkpass", vValidator("query", authorizationSchema), async (c) => {
+	const supabase = createClient<Database>(
+		c.env.SUPABASE_URL,
+		c.env.SUPABASE_KEY,
+	);
+	const { authorization } = c.req.valid("query");
+	const user = await getUserWithProfile(authorization, supabase);
+	if (!user || !user.success) {
+		return c.json({ error: "Unauthorized" }, 401);
+	}
+	const { data: ticket, error } = await supabase
+		.from("tickets")
+		.select()
+		.eq("user_id", user.profile.id)
+		.maybeSingle();
+	if (error) {
+		return c.json({ error: "Internal Server Error" }, 500);
+	}
+	if (!ticket) {
+		return c.json({ error: "Ticket not found" }, 404);
+	}
 
-		const pass = new PKPass(
+	const pass = new PKPass(
+		{
+			"strip@3x.png": Buffer.from(background),
+			"logo@3x.png": Buffer.from(icon),
+			"icon@3x.png": Buffer.from(icon),
+		},
+		{
+			wwdr: atob(c.env.WWDR),
+			signerCert: atob(c.env.SIGNER_CERTIFICATE),
+			signerKey: atob(c.env.SIGNER_KEY),
+		},
+		{
+			description: "FlutterKaigi 2024 Ticket",
+			organizationName: "FlutterKaigi 2024",
+			passTypeIdentifier: "pass.jp.co.flutterkaigi.2024.ticket",
+			teamIdentifier: "6JT949BA2M",
+			serialNumber: ticket.id,
+			contactVenueWebsite: "https://flutterkaigi.jp",
+			backgroundColor: "rgb(255,255,255)",
+			foregroundColor: "rgb(0,0,0)",
+			labelColor: "rgb(0,0,0)",
+			associatedStoreIdentifiers: [6737717479],
+			// チケットの共有は禁止
+			sharingProhibited: true,
+			semantics: {
+				eventName: "FlutterKaigi 2024",
+				eventStartDate: "2024-11-21T09:30+09:00",
+				eventEndDate: "2024-11-22T18:10+09:00",
+				venueRegionName: "東京都江東区",
+				venueName: "有明セントラルタワー ホール&カンファレンス",
+				venueLocation: {
+					latitude: 35.6321071,
+					longitude: 139.7937274,
+				},
+				eventType: "PKEventTypeConference",
+			},
+		},
+	);
+	pass.type = "eventTicket";
+
+	// 2024/11/21 9:30 JST: 入場開始
+	pass.setRelevantDate(new Date("2024-11-21T09:30+09:00"));
+	// 2024/11/22 18:10 JST: 閉会
+	pass.setExpirationDate(new Date("2024-11-22T18:10+09:00"));
+
+	pass.setLocations({
+		latitude: 35.6321071,
+		longitude: 139.7937274,
+		relevantText: "有明セントラルタワー ホール&カンファレンス",
+	});
+
+	let type: string;
+	switch (ticket.type) {
+		case "general": {
+			type = "ATTENDEE";
+			break;
+		}
+		case "individual_sponsor": {
+			type = "PERSONAL SPONSOR";
+			break;
+		}
+		case "regular_speaker": {
+			type = "SPEAKER";
+			break;
+		}
+		case "sponsor_speaker": {
+			type = "SPONSOR SPEAKER";
+			break;
+		}
+		case "sponsor_booth": {
+			type = "SPONSOR BOOTH";
+			break;
+		}
+		case "sponsor_invited": {
+			type = "SPONSOR INVITED";
+			break;
+		}
+		default: {
+			const _exhaustiveCheck: never = ticket.type;
+			return _exhaustiveCheck;
+		}
+	}
+
+	pass.headerFields.push({
+		key: "type",
+		label: "TYPE",
+		value: type,
+	});
+	pass.secondaryFields.push({
+		key: "location",
+		label: "LOCATION",
+		value: "有明セントラルタワー ホール&カンファレンス",
+		attributedValue:
+			"<a href='https://flutterkaigi.jp'>https://flutterkaigi.jp</a>",
+	});
+	pass.auxiliaryFields.push({
+		key: "starts-at",
+		value: "2024-11-21T10:00+09:00",
+		label: "STARTS-AT",
+		timeStyle: "PKDateStyleShort",
+		dateStyle: "PKDateStyleShort",
+	});
+	pass.auxiliaryFields.push(
+		...[
 			{
-				"strip@3x.png": Buffer.from(background),
-				"logo@3x.png": Buffer.from(icon),
-				"icon@3x.png": Buffer.from(icon),
+				key: "name",
+				value: user.profile.name,
+				label: "NAME",
 			},
 			{
-				wwdr: atob(c.env.WWDR),
-				signerCert: atob(c.env.SIGNER_CERTIFICATE),
-				signerKey: atob(c.env.SIGNER_KEY),
+				key: "section",
+				value: ticket.section_id ?? "Unknown",
+				label: "ネームプレート 区画ID",
+			},
+		],
+	);
+	pass.backFields.push(
+		...[
+			{
+				key: "section-id",
+				label: "ネームプレート 区画ID",
+				value: ticket.section_id ?? "不明",
 			},
 			{
-				description: "FlutterKaigi 2024 Ticket",
-				organizationName: "FlutterKaigi 2024",
-				passTypeIdentifier: "pass.jp.co.flutterkaigi.2024.ticket",
-				teamIdentifier: "6JT949BA2M",
-				serialNumber: ticket.id,
-				contactVenueWebsite: "https://flutterkaigi.jp",
-				backgroundColor: "rgb(255,255,255)",
-				foregroundColor: "rgb(0,0,0)",
-				labelColor: "rgb(0,0,0)",
-				associatedStoreIdentifiers: [6737717479],
-				// チケットの共有は禁止
-				sharingProhibited: true,
-				semantics: {
-					eventName: "FlutterKaigi 2024",
-					eventStartDate: "2024-11-21T09:30+09:00",
-					eventEndDate: "2024-11-22T18:10+09:00",
-					venueRegionName: "東京都江東区",
-					venueName: "有明セントラルタワー ホール&カンファレンス",
-					venueLocation: {
-						latitude: 35.6321071,
-						longitude: 139.7937274,
-					},
-					eventType: "PKEventTypeConference",
-				},
+				key: "user-id",
+				label: "ユーザID",
+				value: user.profile.id,
 			},
-		);
-		pass.type = "eventTicket";
-
-		// 2024/11/21 9:30 JST: 入場開始
-		pass.setRelevantDate(new Date("2024-11-21T09:30+09:00"));
-		// 2024/11/22 18:10 JST: 閉会
-		pass.setExpirationDate(new Date("2024-11-22T18:10+09:00"));
-
-		pass.setLocations({
-			latitude: 35.6321071,
-			longitude: 139.7937274,
-			relevantText: "有明セントラルタワー ホール&カンファレンス",
-		});
-
-		let type: string;
-		switch (ticket.type) {
-			case "general": {
-				type = "ATTENDEE";
-				break;
-			}
-			case "individual_sponsor": {
-				type = "PERSONAL SPONSOR";
-				break;
-			}
-			case "regular_speaker": {
-				type = "SPEAKER";
-				break;
-			}
-			case "sponsor_speaker": {
-				type = "SPONSOR SPEAKER";
-				break;
-			}
-			case "sponsor_booth": {
-				type = "SPONSOR BOOTH";
-				break;
-			}
-			case "sponsor_invited": {
-				type = "SPONSOR INVITED";
-				break;
-			}
-			default: {
-				const _exhaustiveCheck: never = ticket.type;
-				return _exhaustiveCheck;
-			}
-		}
-
-		pass.headerFields.push({
-			key: "type",
-			label: "TYPE",
-			value: type,
-		});
-		pass.secondaryFields.push({
-			key: "location",
-			label: "LOCATION",
-			value: "有明セントラルタワー ホール&カンファレンス",
-			attributedValue:
-				"<a href='https://flutterkaigi.jp'>https://flutterkaigi.jp</a>",
-		});
-		pass.auxiliaryFields.push({
-			key: "starts-at",
-			value: "2024-11-21T10:00+09:00",
-			label: "STARTS-AT",
-			timeStyle: "PKDateStyleShort",
-			dateStyle: "PKDateStyleShort",
-		});
-		pass.auxiliaryFields.push(
-			...[{
-			key: "name",
-			value: user.profile.name,
-			label: "NAME",
-		},{
-			key: "section",
-			value: ticket.section_id ?? "Unknown",
-			label: "ネームプレート 区画ID",
-		}]
-		);
-		pass.backFields.push(
-			...[
-				{
-					"key": "section-id",
-					label: "ネームプレート 区画ID",
-					value: ticket.section_id ?? "不明",
-				},
-				{
-					key: "user-id",
-					label: "ユーザID",
-					value: user.profile.id,
-				},
-				{
-					key: "ticket-id",
-					label: "チケットID",
-					value: ticket.id,
-				},
-				{
-					key: "payment-id",
-					label: "決済ID",
-					value: ticket.stripe_checkout_session_id ?? "不明",
-				},
-			],
-		);
-
-		pass.setBarcodes(
-			...[
-				{
-					format: "PKBarcodeFormatQR",
-					// Ticket ID
-					message: ticket.id,
-					altText: `T-${ticket.id.slice(0, 8)}`,
-				} satisfies Barcode,
-			],
-		);
-		pass.preferredStyleSchemes = ["posterEventTicket", "eventTicket"];
-
-		return new Response(pass.getAsBuffer(), {
-			headers: {
-				"Content-type": pass.mimeType,
-				"Content-disposition": "attachment; filename=pass.pkpass",
+			{
+				key: "ticket-id",
+				label: "チケットID",
+				value: ticket.id,
 			},
-		});
-	},
-);
+			{
+				key: "payment-id",
+				label: "決済ID",
+				value: ticket.stripe_checkout_session_id ?? "不明",
+			},
+		],
+	);
+
+	pass.setBarcodes(
+		...[
+			{
+				format: "PKBarcodeFormatQR",
+				// Ticket ID
+				message: ticket.id,
+				altText: `T-${ticket.id.slice(0, 8)}`,
+			} satisfies Barcode,
+		],
+	);
+	pass.preferredStyleSchemes = ["posterEventTicket", "eventTicket"];
+
+	return new Response(pass.getAsBuffer(), {
+		headers: {
+			"Content-type": pass.mimeType,
+			"Content-disposition": "attachment; filename=pass.pkpass",
+		},
+	});
+});
 
 export default app;

--- a/packages/common/ticket_api/lib/model/payment/payment_refund_response.dart
+++ b/packages/common/ticket_api/lib/model/payment/payment_refund_response.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'payment_refund_response.freezed.dart';
+part 'payment_refund_response.g.dart';
+
+@freezed
+class PaymentRefundResponse with _$PaymentRefundResponse {
+  const factory PaymentRefundResponse({
+    required String refund,
+  }) = _PaymentRefundResponse;
+
+  factory PaymentRefundResponse.fromJson(Map<String, dynamic> json) =>
+      _$PaymentRefundResponseFromJson(json);
+}

--- a/packages/common/ticket_api/lib/model/payment/payment_refund_response.freezed.dart
+++ b/packages/common/ticket_api/lib/model/payment/payment_refund_response.freezed.dart
@@ -1,0 +1,170 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'payment_refund_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PaymentRefundResponse _$PaymentRefundResponseFromJson(
+    Map<String, dynamic> json) {
+  return _PaymentRefundResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PaymentRefundResponse {
+  String get refund => throw _privateConstructorUsedError;
+
+  /// Serializes this PaymentRefundResponse to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of PaymentRefundResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PaymentRefundResponseCopyWith<PaymentRefundResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PaymentRefundResponseCopyWith<$Res> {
+  factory $PaymentRefundResponseCopyWith(PaymentRefundResponse value,
+          $Res Function(PaymentRefundResponse) then) =
+      _$PaymentRefundResponseCopyWithImpl<$Res, PaymentRefundResponse>;
+  @useResult
+  $Res call({String refund});
+}
+
+/// @nodoc
+class _$PaymentRefundResponseCopyWithImpl<$Res,
+        $Val extends PaymentRefundResponse>
+    implements $PaymentRefundResponseCopyWith<$Res> {
+  _$PaymentRefundResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of PaymentRefundResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? refund = null,
+  }) {
+    return _then(_value.copyWith(
+      refund: null == refund
+          ? _value.refund
+          : refund // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PaymentRefundResponseImplCopyWith<$Res>
+    implements $PaymentRefundResponseCopyWith<$Res> {
+  factory _$$PaymentRefundResponseImplCopyWith(
+          _$PaymentRefundResponseImpl value,
+          $Res Function(_$PaymentRefundResponseImpl) then) =
+      __$$PaymentRefundResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String refund});
+}
+
+/// @nodoc
+class __$$PaymentRefundResponseImplCopyWithImpl<$Res>
+    extends _$PaymentRefundResponseCopyWithImpl<$Res,
+        _$PaymentRefundResponseImpl>
+    implements _$$PaymentRefundResponseImplCopyWith<$Res> {
+  __$$PaymentRefundResponseImplCopyWithImpl(_$PaymentRefundResponseImpl _value,
+      $Res Function(_$PaymentRefundResponseImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of PaymentRefundResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? refund = null,
+  }) {
+    return _then(_$PaymentRefundResponseImpl(
+      refund: null == refund
+          ? _value.refund
+          : refund // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PaymentRefundResponseImpl implements _PaymentRefundResponse {
+  const _$PaymentRefundResponseImpl({required this.refund});
+
+  factory _$PaymentRefundResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PaymentRefundResponseImplFromJson(json);
+
+  @override
+  final String refund;
+
+  @override
+  String toString() {
+    return 'PaymentRefundResponse(refund: $refund)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PaymentRefundResponseImpl &&
+            (identical(other.refund, refund) || other.refund == refund));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, refund);
+
+  /// Create a copy of PaymentRefundResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PaymentRefundResponseImplCopyWith<_$PaymentRefundResponseImpl>
+      get copyWith => __$$PaymentRefundResponseImplCopyWithImpl<
+          _$PaymentRefundResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PaymentRefundResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PaymentRefundResponse implements PaymentRefundResponse {
+  const factory _PaymentRefundResponse({required final String refund}) =
+      _$PaymentRefundResponseImpl;
+
+  factory _PaymentRefundResponse.fromJson(Map<String, dynamic> json) =
+      _$PaymentRefundResponseImpl.fromJson;
+
+  @override
+  String get refund;
+
+  /// Create a copy of PaymentRefundResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PaymentRefundResponseImplCopyWith<_$PaymentRefundResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/common/ticket_api/lib/model/payment/payment_refund_response.g.dart
+++ b/packages/common/ticket_api/lib/model/payment/payment_refund_response.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'payment_refund_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PaymentRefundResponseImpl _$$PaymentRefundResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$PaymentRefundResponseImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$PaymentRefundResponseImpl(
+          refund: $checkedConvert('refund', (v) => v as String),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$PaymentRefundResponseImplToJson(
+        _$PaymentRefundResponseImpl instance) =>
+    <String, dynamic>{
+      'refund': instance.refund,
+    };

--- a/packages/common/ticket_api/lib/model/payment/payment_search_response.dart
+++ b/packages/common/ticket_api/lib/model/payment/payment_search_response.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'payment_search_response.freezed.dart';
+part 'payment_search_response.g.dart';
+
+@freezed
+class PaymentSearchResponse with _$PaymentSearchResponse {
+  const factory PaymentSearchResponse({
+    required List<PaymentResult> results,
+  }) = _PaymentSearchResponse;
+
+  factory PaymentSearchResponse.fromJson(Map<String, dynamic> json) =>
+      _$PaymentSearchResponseFromJson(json);
+}
+
+@freezed
+class PaymentResult with _$PaymentResult {
+  const factory PaymentResult({
+    required String paymentIntent,
+    required int amount,
+    required DateTime createdAt,
+  }) = _PaymentResult;
+
+  factory PaymentResult.fromJson(Map<String, dynamic> json) =>
+      _$PaymentResultFromJson(json);
+}

--- a/packages/common/ticket_api/lib/model/payment/payment_search_response.freezed.dart
+++ b/packages/common/ticket_api/lib/model/payment/payment_search_response.freezed.dart
@@ -1,0 +1,369 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'payment_search_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PaymentSearchResponse _$PaymentSearchResponseFromJson(
+    Map<String, dynamic> json) {
+  return _PaymentSearchResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PaymentSearchResponse {
+  List<PaymentResult> get results => throw _privateConstructorUsedError;
+
+  /// Serializes this PaymentSearchResponse to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of PaymentSearchResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PaymentSearchResponseCopyWith<PaymentSearchResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PaymentSearchResponseCopyWith<$Res> {
+  factory $PaymentSearchResponseCopyWith(PaymentSearchResponse value,
+          $Res Function(PaymentSearchResponse) then) =
+      _$PaymentSearchResponseCopyWithImpl<$Res, PaymentSearchResponse>;
+  @useResult
+  $Res call({List<PaymentResult> results});
+}
+
+/// @nodoc
+class _$PaymentSearchResponseCopyWithImpl<$Res,
+        $Val extends PaymentSearchResponse>
+    implements $PaymentSearchResponseCopyWith<$Res> {
+  _$PaymentSearchResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of PaymentSearchResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? results = null,
+  }) {
+    return _then(_value.copyWith(
+      results: null == results
+          ? _value.results
+          : results // ignore: cast_nullable_to_non_nullable
+              as List<PaymentResult>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PaymentSearchResponseImplCopyWith<$Res>
+    implements $PaymentSearchResponseCopyWith<$Res> {
+  factory _$$PaymentSearchResponseImplCopyWith(
+          _$PaymentSearchResponseImpl value,
+          $Res Function(_$PaymentSearchResponseImpl) then) =
+      __$$PaymentSearchResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<PaymentResult> results});
+}
+
+/// @nodoc
+class __$$PaymentSearchResponseImplCopyWithImpl<$Res>
+    extends _$PaymentSearchResponseCopyWithImpl<$Res,
+        _$PaymentSearchResponseImpl>
+    implements _$$PaymentSearchResponseImplCopyWith<$Res> {
+  __$$PaymentSearchResponseImplCopyWithImpl(_$PaymentSearchResponseImpl _value,
+      $Res Function(_$PaymentSearchResponseImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of PaymentSearchResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? results = null,
+  }) {
+    return _then(_$PaymentSearchResponseImpl(
+      results: null == results
+          ? _value._results
+          : results // ignore: cast_nullable_to_non_nullable
+              as List<PaymentResult>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PaymentSearchResponseImpl implements _PaymentSearchResponse {
+  const _$PaymentSearchResponseImpl(
+      {required final List<PaymentResult> results})
+      : _results = results;
+
+  factory _$PaymentSearchResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PaymentSearchResponseImplFromJson(json);
+
+  final List<PaymentResult> _results;
+  @override
+  List<PaymentResult> get results {
+    if (_results is EqualUnmodifiableListView) return _results;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_results);
+  }
+
+  @override
+  String toString() {
+    return 'PaymentSearchResponse(results: $results)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PaymentSearchResponseImpl &&
+            const DeepCollectionEquality().equals(other._results, _results));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_results));
+
+  /// Create a copy of PaymentSearchResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PaymentSearchResponseImplCopyWith<_$PaymentSearchResponseImpl>
+      get copyWith => __$$PaymentSearchResponseImplCopyWithImpl<
+          _$PaymentSearchResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PaymentSearchResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PaymentSearchResponse implements PaymentSearchResponse {
+  const factory _PaymentSearchResponse(
+          {required final List<PaymentResult> results}) =
+      _$PaymentSearchResponseImpl;
+
+  factory _PaymentSearchResponse.fromJson(Map<String, dynamic> json) =
+      _$PaymentSearchResponseImpl.fromJson;
+
+  @override
+  List<PaymentResult> get results;
+
+  /// Create a copy of PaymentSearchResponse
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PaymentSearchResponseImplCopyWith<_$PaymentSearchResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+PaymentResult _$PaymentResultFromJson(Map<String, dynamic> json) {
+  return _PaymentResult.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PaymentResult {
+  String get paymentIntent => throw _privateConstructorUsedError;
+  int get amount => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+
+  /// Serializes this PaymentResult to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of PaymentResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PaymentResultCopyWith<PaymentResult> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PaymentResultCopyWith<$Res> {
+  factory $PaymentResultCopyWith(
+          PaymentResult value, $Res Function(PaymentResult) then) =
+      _$PaymentResultCopyWithImpl<$Res, PaymentResult>;
+  @useResult
+  $Res call({String paymentIntent, int amount, DateTime createdAt});
+}
+
+/// @nodoc
+class _$PaymentResultCopyWithImpl<$Res, $Val extends PaymentResult>
+    implements $PaymentResultCopyWith<$Res> {
+  _$PaymentResultCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of PaymentResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? paymentIntent = null,
+    Object? amount = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_value.copyWith(
+      paymentIntent: null == paymentIntent
+          ? _value.paymentIntent
+          : paymentIntent // ignore: cast_nullable_to_non_nullable
+              as String,
+      amount: null == amount
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PaymentResultImplCopyWith<$Res>
+    implements $PaymentResultCopyWith<$Res> {
+  factory _$$PaymentResultImplCopyWith(
+          _$PaymentResultImpl value, $Res Function(_$PaymentResultImpl) then) =
+      __$$PaymentResultImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String paymentIntent, int amount, DateTime createdAt});
+}
+
+/// @nodoc
+class __$$PaymentResultImplCopyWithImpl<$Res>
+    extends _$PaymentResultCopyWithImpl<$Res, _$PaymentResultImpl>
+    implements _$$PaymentResultImplCopyWith<$Res> {
+  __$$PaymentResultImplCopyWithImpl(
+      _$PaymentResultImpl _value, $Res Function(_$PaymentResultImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of PaymentResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? paymentIntent = null,
+    Object? amount = null,
+    Object? createdAt = null,
+  }) {
+    return _then(_$PaymentResultImpl(
+      paymentIntent: null == paymentIntent
+          ? _value.paymentIntent
+          : paymentIntent // ignore: cast_nullable_to_non_nullable
+              as String,
+      amount: null == amount
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PaymentResultImpl implements _PaymentResult {
+  const _$PaymentResultImpl(
+      {required this.paymentIntent,
+      required this.amount,
+      required this.createdAt});
+
+  factory _$PaymentResultImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PaymentResultImplFromJson(json);
+
+  @override
+  final String paymentIntent;
+  @override
+  final int amount;
+  @override
+  final DateTime createdAt;
+
+  @override
+  String toString() {
+    return 'PaymentResult(paymentIntent: $paymentIntent, amount: $amount, createdAt: $createdAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PaymentResultImpl &&
+            (identical(other.paymentIntent, paymentIntent) ||
+                other.paymentIntent == paymentIntent) &&
+            (identical(other.amount, amount) || other.amount == amount) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, paymentIntent, amount, createdAt);
+
+  /// Create a copy of PaymentResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PaymentResultImplCopyWith<_$PaymentResultImpl> get copyWith =>
+      __$$PaymentResultImplCopyWithImpl<_$PaymentResultImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PaymentResultImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PaymentResult implements PaymentResult {
+  const factory _PaymentResult(
+      {required final String paymentIntent,
+      required final int amount,
+      required final DateTime createdAt}) = _$PaymentResultImpl;
+
+  factory _PaymentResult.fromJson(Map<String, dynamic> json) =
+      _$PaymentResultImpl.fromJson;
+
+  @override
+  String get paymentIntent;
+  @override
+  int get amount;
+  @override
+  DateTime get createdAt;
+
+  /// Create a copy of PaymentResult
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PaymentResultImplCopyWith<_$PaymentResultImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/common/ticket_api/lib/model/payment/payment_search_response.g.dart
+++ b/packages/common/ticket_api/lib/model/payment/payment_search_response.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, duplicate_ignore
+
+part of 'payment_search_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PaymentSearchResponseImpl _$$PaymentSearchResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$PaymentSearchResponseImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$PaymentSearchResponseImpl(
+          results: $checkedConvert(
+              'results',
+              (v) => (v as List<dynamic>)
+                  .map((e) => PaymentResult.fromJson(e as Map<String, dynamic>))
+                  .toList()),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$PaymentSearchResponseImplToJson(
+        _$PaymentSearchResponseImpl instance) =>
+    <String, dynamic>{
+      'results': instance.results,
+    };
+
+_$PaymentResultImpl _$$PaymentResultImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$PaymentResultImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$PaymentResultImpl(
+          paymentIntent: $checkedConvert('paymentIntent', (v) => v as String),
+          amount: $checkedConvert('amount', (v) => (v as num).toInt()),
+          createdAt:
+              $checkedConvert('createdAt', (v) => DateTime.parse(v as String)),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$PaymentResultImplToJson(_$PaymentResultImpl instance) =>
+    <String, dynamic>{
+      'paymentIntent': instance.paymentIntent,
+      'amount': instance.amount,
+      'createdAt': instance.createdAt.toIso8601String(),
+    };

--- a/packages/common/ticket_api/lib/ticket_api.dart
+++ b/packages/common/ticket_api/lib/ticket_api.dart
@@ -2,6 +2,8 @@ import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:ticket_api/model/payment/payment_refund_response.dart';
+import 'package:ticket_api/model/payment/payment_search_response.dart';
 import 'package:ticket_api/model/ticket/get_promotion_response.dart';
 import 'package:ticket_api/model/ticket/post_promotion_request.dart';
 import 'package:ticket_api/model/ticket/post_promotion_response.dart';
@@ -50,5 +52,18 @@ abstract class TicketApiClient {
   Future<PostPromotionResponse> postPromotion({
     @Header('Authorization') required String authorization,
     @Body() required PostPromotionRequest body,
+  });
+
+  @GET('/v1/payment/search')
+  Future<PaymentSearchResponse> searchPayments({
+    @Query('email') required String email,
+    @Header('Authorization') required String authorization,
+  });
+
+  @POST('/v1/payment/refund')
+  Future<PaymentRefundResponse> refundPayment({
+    @Query('payment_intent') required String paymentIntent,
+    @Query('user_id') required String userId,
+    @Header('Authorization') required String authorization,
   });
 }

--- a/packages/common/ticket_api/lib/ticket_api.g.dart
+++ b/packages/common/ticket_api/lib/ticket_api.g.dart
@@ -137,6 +137,84 @@ class _TicketApiClient implements TicketApiClient {
     return _value;
   }
 
+  @override
+  Future<PaymentSearchResponse> searchPayments({
+    required String email,
+    required String authorization,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'email': email};
+    final _headers = <String, dynamic>{r'Authorization': authorization};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<PaymentSearchResponse>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/v1/payment/search',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late PaymentSearchResponse _value;
+    try {
+      _value = PaymentSearchResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<PaymentRefundResponse> refundPayment({
+    required String paymentIntent,
+    required String userId,
+    required String authorization,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{
+      r'payment_intent': paymentIntent,
+      r'user_id': userId,
+    };
+    final _headers = <String, dynamic>{r'Authorization': authorization};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<PaymentRefundResponse>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/v1/payment/refund',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late PaymentRefundResponse _value;
+    try {
+      _value = PaymentRefundResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,19 +64,19 @@ importers:
     dependencies:
       '@hono-rate-limiter/cloudflare':
         specifier: ^0.2.1
-        version: 0.2.1(@cloudflare/workers-types@4.20241022.0)(hono@4.6.8)
+        version: 0.2.1(@cloudflare/workers-types@4.20241112.0)(hono@4.6.10)
       '@hono/valibot-validator':
         specifier: ^0.3.1
-        version: 0.3.1(hono@4.6.8)(valibot@0.41.0(typescript@5.6.3))
+        version: 0.3.1(hono@4.6.10)(valibot@0.41.0(typescript@5.6.3))
       '@supabase/supabase-js':
-        specifier: ^2.45.4
+        specifier: ^2.46.1
         version: 2.46.1
       hono:
-        specifier: ^4.6.5
-        version: 4.6.8
+        specifier: ^4.6.10
+        version: 4.6.10
       hono-rate-limiter:
         specifier: ^0.4.0
-        version: 0.4.0(hono@4.6.8)
+        version: 0.4.0(hono@4.6.10)
       passkit-generator:
         specifier: ^3.2.0
         version: 3.2.0
@@ -94,14 +94,14 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@cloudflare/workers-types':
-        specifier: ^4.20241011.0
-        version: 4.20241022.0
+        specifier: ^4.20241112.0
+        version: 4.20241112.0
       configs:
         specifier: workspace:*
         version: link:../configs
       wrangler:
-        specifier: ^3.80.4
-        version: 3.84.1(@cloudflare/workers-types@4.20241022.0)
+        specifier: ^3.87.0
+        version: 3.87.0(@cloudflare/workers-types@4.20241112.0)
 
   apis/website-html-rewriter:
     dependencies:
@@ -234,8 +234,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20241106.1':
+    resolution: {integrity: sha512-zxvaToi1m0qzAScrxFt7UvFVqU8DxrCO2CinM1yQkv5no7pA1HolpIrwZ0xOhR3ny64Is2s/J6BrRjpO5dM9Zw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20241022.0':
     resolution: {integrity: sha512-FOO/0P0U82EsTLTdweNVgw+4VOk5nghExLPLSppdOziq6IR5HVgP44Kmq5LdsUeHUhwUmfOh9hzaTpkNzUqKvw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20241106.1':
+    resolution: {integrity: sha512-j3dg/42D/bPgfNP3cRUBxF+4waCKO/5YKwXNj+lnVOwHxDu+ne5pFw9TIkKYcWTcwn0ZUkbNZNM5rhJqRn4xbg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -246,8 +258,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20241106.1':
+    resolution: {integrity: sha512-Ih+Ye8E1DMBXcKrJktGfGztFqHKaX1CeByqshmTbODnWKHt6O65ax3oTecUwyC0+abuyraOpAtdhHNpFMhUkmw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20241022.0':
     resolution: {integrity: sha512-x5mUXpKxfsosxcFmcq5DaqLs37PejHYVRsNz1cWI59ma7aC4y4Qn6Tf3i0r9MwQTF/MccP4SjVslMU6m4W7IaA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20241106.1':
+    resolution: {integrity: sha512-mdQFPk4+14Yywn7n1xIzI+6olWM8Ybz10R7H3h+rk0XulMumCWUCy1CzIDauOx6GyIcSgKIibYMssVHZR30ObA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
@@ -258,12 +282,25 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@cloudflare/workerd-windows-64@1.20241106.1':
+    resolution: {integrity: sha512-4rtcss31E/Rb/PeFocZfr+B9i1MdrkhsTBWizh8siNR4KMmkslU2xs2wPaH1z8+ErxkOsHrKRa5EPLh5rIiFeg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
   '@cloudflare/workers-shared@0.7.0':
     resolution: {integrity: sha512-LLQRTqx7lKC7o2eCYMpyc5FXV8d0pUX6r3A+agzhqS9aoR5A6zCPefwQGcvbKx83ozX22ATZcemwxQXn12UofQ==}
     engines: {node: '>=16.7.0'}
 
+  '@cloudflare/workers-shared@0.7.1':
+    resolution: {integrity: sha512-46cP5FCrl3TrvHeoHLb5SRuiDMKH5kc9Yvo36SAfzt8dqJI/qJRoY1GP3ioHn/gP7v2QIoUOTAzIl7Ml7MnfrA==}
+    engines: {node: '>=16.7.0'}
+
   '@cloudflare/workers-types@4.20241022.0':
     resolution: {integrity: sha512-1zOAw5QIDKItzGatzCrEpfLOB1AuMTwVqKmbw9B9eBfCUGRFNfJYMrJxIwcse9EmKahsQt2GruqU00pY/GyXgg==}
+
+  '@cloudflare/workers-types@4.20241112.0':
+    resolution: {integrity: sha512-Q4p9bAWZrX14bSCKY9to19xl0KMU7nsO5sJ2cTVspHoypsjPUMeQCsjHjmsO2C4Myo8/LPeDvmqFmkyNAPPYZw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -755,6 +792,9 @@ packages:
   '@types/node@20.12.14':
     resolution: {integrity: sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg==}
 
+  '@types/node@22.9.0':
+    resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
+
   '@types/phoenix@1.6.5':
     resolution: {integrity: sha512-xegpDuR+z0UqG9fwHqNoy3rI7JDlvaPh2TY47Fl80oq6g+hXT+c/LEuE43X48clZ6lOfANl5WrPur9fYO1RJ/w==}
 
@@ -901,6 +941,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
 
   clone-regexp@2.2.0:
     resolution: {integrity: sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==}
@@ -1223,6 +1267,10 @@ packages:
     resolution: {integrity: sha512-7RWU2HZvxPtfBrvjXKDiQ3F6ZH8k49JhxVkHquUz5UZKjauj5PrP29MvISykThtfpy4mGG6kqxFBHW1ed9wwnA==}
     peerDependencies:
       hono: ^4.1.1
+
+  hono@4.6.10:
+    resolution: {integrity: sha512-IXXNfRAZEahFnWBhUUlqKEGF9upeE6hZoRZszvNkyAz/CYp+iVbxm3viMvStlagRJohjlBRGOQ7f4jfcV0XMGg==}
+    engines: {node: '>=16.9.0'}
 
   hono@4.6.8:
     resolution: {integrity: sha512-f+2Ec9JAzabT61pglDiLJcF/DjiSefZkjCn9bzm1cYLGkD5ExJ3Jnv93ax9h0bn7UPLHF81KktoyjdQfWI2n1Q==}
@@ -1576,6 +1624,11 @@ packages:
     engines: {node: '>=16.13'}
     hasBin: true
 
+  miniflare@3.20241106.0:
+    resolution: {integrity: sha512-PjOoJKjUUofCueQskfhXlGvvHxZj36UAJAp1DnquMK88MFF50zCULblh0KXMSNM+bXeQYA94Gj06a7kfmBGxPw==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+
   minimatch@10.0.1:
     resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
     engines: {node: 20 || >=22}
@@ -1807,6 +1860,10 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
+  qs@6.13.1:
+    resolution: {integrity: sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==}
+    engines: {node: '>=0.6'}
+
   rc-config-loader@4.1.3:
     resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
 
@@ -1829,6 +1886,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  readdirp@4.0.2:
+    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
+    engines: {node: '>= 14.16.0'}
 
   readline-sync@1.4.10:
     resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
@@ -2135,6 +2196,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
@@ -2204,12 +2268,27 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20241106.1:
+    resolution: {integrity: sha512-1GdKl0kDw8rrirr/ThcK66Kbl4/jd4h8uHx5g7YHBrnenY5SX1UPuop2cnCzYUxlg55kPjzIqqYslz1muRFgFw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrangler@3.84.1:
     resolution: {integrity: sha512-w27/QpIk2qz6aMIVi9T8cDcXMvh/RXjcL+vf4o5J2GpQAE4U7wTCNHyaY9H3oTJWRN97KqCAEbiHBNtTKoUJEw==}
     engines: {node: '>=16.17.0'}
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20241022.0
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@3.87.0:
+    resolution: {integrity: sha512-BExktnSLeGgG+uxgnr4h9eZ5nefdpTVcTHR+gEIWRvqk07XL04nJwpPYAOIPKPpB7E2tMdDJgNLGQN/CY6e1xQ==}
+    engines: {node: '>=16.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20241106.0
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -2328,16 +2407,31 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20241022.0':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20241106.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20241022.0':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20241106.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20241022.0':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20241106.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20241022.0':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20241106.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20241022.0':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20241106.1':
     optional: true
 
   '@cloudflare/workers-shared@0.7.0':
@@ -2345,7 +2439,14 @@ snapshots:
       mime: 3.0.0
       zod: 3.23.8
 
+  '@cloudflare/workers-shared@0.7.1':
+    dependencies:
+      mime: 3.0.0
+      zod: 3.23.8
+
   '@cloudflare/workers-types@4.20241022.0': {}
+
+  '@cloudflare/workers-types@4.20241112.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -2523,10 +2624,15 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hono-rate-limiter/cloudflare@0.2.1(@cloudflare/workers-types@4.20241022.0)(hono@4.6.8)':
+  '@hono-rate-limiter/cloudflare@0.2.1(@cloudflare/workers-types@4.20241112.0)(hono@4.6.10)':
     dependencies:
-      '@cloudflare/workers-types': 4.20241022.0
-      hono: 4.6.8
+      '@cloudflare/workers-types': 4.20241112.0
+      hono: 4.6.10
+
+  '@hono/valibot-validator@0.3.1(hono@4.6.10)(valibot@0.41.0(typescript@5.6.3))':
+    dependencies:
+      hono: 4.6.10
+      valibot: 0.41.0(typescript@5.6.3)
 
   '@hono/valibot-validator@0.3.1(hono@4.6.8)(valibot@0.41.0(typescript@5.6.3))':
     dependencies:
@@ -2826,11 +2932,15 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 20.12.14
+      '@types/node': 22.9.0
 
   '@types/node@20.12.14':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@22.9.0':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/phoenix@1.6.5': {}
 
@@ -2983,6 +3093,10 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chokidar@4.0.1:
+    dependencies:
+      readdirp: 4.0.2
 
   clone-regexp@2.2.0:
     dependencies:
@@ -3343,9 +3457,11 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono-rate-limiter@0.4.0(hono@4.6.8):
+  hono-rate-limiter@0.4.0(hono@4.6.10):
     dependencies:
-      hono: 4.6.8
+      hono: 4.6.10
+
+  hono@4.6.10: {}
 
   hono@4.6.8: {}
 
@@ -3767,6 +3883,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  miniflare@3.20241106.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      capnp-ts: 0.7.0
+      exit-hook: 2.2.1
+      glob-to-regexp: 0.4.1
+      stoppable: 1.1.0
+      undici: 5.28.4
+      workerd: 1.20241106.1
+      ws: 8.18.0
+      youch: 3.3.4
+      zod: 3.23.8
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   minimatch@10.0.1:
     dependencies:
       brace-expansion: 2.0.1
@@ -3967,6 +4102,10 @@ snapshots:
     dependencies:
       side-channel: 1.0.6
 
+  qs@6.13.1:
+    dependencies:
+      side-channel: 1.0.6
+
   rc-config-loader@4.1.3:
     dependencies:
       debug: 4.3.7
@@ -4000,6 +4139,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.0.2: {}
 
   readline-sync@1.4.10: {}
 
@@ -4190,8 +4331,8 @@ snapshots:
 
   stripe@16.12.0:
     dependencies:
-      '@types/node': 20.12.14
-      qs: 6.13.0
+      '@types/node': 22.9.0
+      qs: 6.13.1
 
   structured-source@4.0.0:
     dependencies:
@@ -4355,6 +4496,8 @@ snapshots:
 
   undici-types@5.26.5: {}
 
+  undici-types@6.19.8: {}
+
   undici@5.28.4:
     dependencies:
       '@fastify/busboy': 2.1.1
@@ -4441,6 +4584,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20241022.0
       '@cloudflare/workerd-windows-64': 1.20241022.0
 
+  workerd@1.20241106.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20241106.1
+      '@cloudflare/workerd-darwin-arm64': 1.20241106.1
+      '@cloudflare/workerd-linux-64': 1.20241106.1
+      '@cloudflare/workerd-linux-arm64': 1.20241106.1
+      '@cloudflare/workerd-windows-64': 1.20241106.1
+
   wrangler@3.84.1(@cloudflare/workers-types@4.20241022.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
@@ -4464,6 +4615,35 @@ snapshots:
       xxhash-wasm: 1.0.2
     optionalDependencies:
       '@cloudflare/workers-types': 4.20241022.0
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  wrangler@3.87.0(@cloudflare/workers-types@4.20241112.0):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.3.4
+      '@cloudflare/workers-shared': 0.7.1
+      '@esbuild-plugins/node-globals-polyfill': 0.2.3(esbuild@0.17.19)
+      '@esbuild-plugins/node-modules-polyfill': 0.2.2(esbuild@0.17.19)
+      blake3-wasm: 2.1.5
+      chokidar: 4.0.1
+      date-fns: 4.1.0
+      esbuild: 0.17.19
+      itty-time: 1.0.6
+      miniflare: 3.20241106.0
+      nanoid: 3.3.7
+      path-to-regexp: 6.3.0
+      resolve: 1.22.8
+      resolve.exports: 2.0.2
+      selfsigned: 2.4.1
+      source-map: 0.6.1
+      unenv: unenv-nightly@2.0.0-20241024-111401-d4156ac
+      workerd: 1.20241106.1
+      xxhash-wasm: 1.0.2
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20241112.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## 説明

- 返金APIを実装しました  
すべての返金関連APIは`role() = admin` のみ実行可能です
  - `v1/payment/search` Emailから支払いIDを検索するAPI
  - `v1/payment/refund` 支払いIDの支払いを返金するAPI
    - 返金に成功・失敗した時にSlack Incoming webhook経由で通知が行きます