### PR TITLE
fix(data): sectionsテーブルに対するRLSを有効化

### DIFF
--- a/packages/common/data/supabase/migrations/20241120145542_alter_section_rls.sql
+++ b/packages/common/data/supabase/migrations/20241120145542_alter_section_rls.sql
@@ -1,0 +1,7 @@
+ALTER TABLE sections enable ROW level security;
+
+CREATE POLICY "Authorized users can select sections" ON sections FOR
+SELECT
+  TO authenticated USING (TRUE);
+
+CREATE POLICY "Admins can CRUD sections" ON sections FOR ALL TO authenticated USING (auth.role () = 'admin');


### PR DESCRIPTION
## 説明

- 区画IDを保管する`public.sections`テーブルに対するRLSが有効になっていなかった
  - 任意のユーザがSELECTしても問題のないテーブルではある
  - UPDATE/DELETE/CREATE されておらず、意図したデータが保持されていることは確認しました
- production/staging環境にmigration済みです 