### PR TITLE
chore(ticket-api): チケット販売状況のSlack Notifyを行うCron Triggerを削除

### DIFF
--- a/apis/ticket-api/wrangler.toml
+++ b/apis/ticket-api/wrangler.toml
@@ -15,8 +15,8 @@ enabled = true
 
 [env.production]
 
-[env.production.triggers]
+#[env.production.triggers]
 # Everyday at 21:00 JST
-crons = ["0 12 * * *"]
+# crons = ["0 12 * * *"]
 
 [env.staging]

--- a/apis/ticket-api/wrangler.toml
+++ b/apis/ticket-api/wrangler.toml
@@ -15,7 +15,7 @@ enabled = true
 
 [env.production]
 
-#[env.production.triggers]
+# [env.production.triggers]
 # Everyday at 21:00 JST
 # crons = ["0 12 * * *"]
 


### PR DESCRIPTION
## 説明

- タイトルの通りです。
  - 特記事項はありません。