### PR TITLE
[App] fix: 小さな画面でフォント設定の選択ダイアログにて Bottom Overflow が発生する不具合を修正

### DIFF
--- a/apps/app/ios/Podfile.lock
+++ b/apps/app/ios/Podfile.lock
@@ -91,9 +91,6 @@ PODS:
     - FlutterMacOS
   - url_launcher_ios (0.0.1):
     - Flutter
-  - webview_flutter_wkwebview (0.0.1):
-    - Flutter
-    - FlutterMacOS
 
 DEPENDENCIES:
   - add_2_calendar (from `.symlinks/plugins/add_2_calendar/ios`)
@@ -108,7 +105,6 @@ DEPENDENCIES:
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
-  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -148,8 +144,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
-  webview_flutter_wkwebview:
-    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
   add_2_calendar: 5eee66d5a3b99cd5e1487a7e03abd4e3ac4aff11
@@ -174,7 +168,6 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  webview_flutter_wkwebview: 0982481e3d9c78fd5c6f62a002fcd24fc791f1e4
 
 PODFILE CHECKSUM: 493282eddd11df4d4276aaebabfcb63901559823
 

--- a/packages/app/cores/settings/lib/src/ui/settings_page.dart
+++ b/packages/app/cores/settings/lib/src/ui/settings_page.dart
@@ -326,19 +326,20 @@ class _ListSelectionDialog<T> extends HookWidget {
     final currentSelection = useState<T?>(initialValue);
     return AlertDialog(
       title: Text(title),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          for (final value in values)
-            RadioListTile<T>(
-              title: tileTitleBuilder(value),
-              value: value,
-              groupValue: currentSelection.value,
-              onChanged: (value) {
-                currentSelection.value = value;
-              },
-            ),
-        ],
+      content: SingleChildScrollView(
+        child: ListBody(
+          children: [
+            for (final value in values)
+              RadioListTile<T>(
+                title: tileTitleBuilder(value),
+                value: value,
+                groupValue: currentSelection.value,
+                onChanged: (value) {
+                  currentSelection.value = value;
+                },
+              ),
+          ],
+        ),
       ),
       actions: [
         TextButton(


### PR DESCRIPTION
## Issue

- Closes #521 

## 説明

小さな画面でフォント設定の選択ダイアログにて Bottom Overflow が発生する不具合を修正しました。

[公式ドキュメント](https://api.flutter.dev/flutter/material/AlertDialog-class.html#:~:text=Alert%20dialogs%20and%20scrolling) にある通り、[SingleChildScrollView](https://api.flutter.dev/flutter/widgets/SingleChildScrollView-class.html) と [ListBody](https://api.flutter.dev/flutter/widgets/ListBody-class.html) を使って対応しました。

## 画像 / 動画

| Before | After |
|-|-|
| <img src="https://github.com/user-attachments/assets/04d12637-fa49-4476-bdea-9f9917b6b2e3" width="300" /> | <video src="https://github.com/user-attachments/assets/3d646dc8-c2b7-431c-9b6c-3151411c1831" width=320 /> |

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
