### PR TITLE
[Data] chore: コントリビューターを更新するワークフローのスケジュール設定を削除

### DIFF
--- a/.github/workflows/replace-contributors.yaml
+++ b/.github/workflows/replace-contributors.yaml
@@ -2,8 +2,6 @@ name: "Replace Contributors"
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *" # 毎日9:00(JST)に実行
 
 jobs:
   replace-contributors:


### PR DESCRIPTION
## Issue

- Closes #565 

## 説明

頻繁なコントリビューターの更新処理が不要になったため、↓のファイルの schedule の部分を削除しました。
replace-contributors.yaml

リポジトリのアーカイブでもワークフローの実行を抑制できると思いますが、もう少し開発続くと思ったのでいったんこのように対応することにしました。

## 画像 / 動画

見た目の変更がないため省略します。

## その他

<!--
参考にしたものがあれば書いてください。
また、注意することなどあればあわせて書いてください。
-->
