### PR TITLE
chore: チケットWebの本番環境デプロイを停止

### DIFF
--- a/.github/workflows/deploy-ticket.yaml
+++ b/.github/workflows/deploy-ticket.yaml
@@ -62,7 +62,7 @@ jobs:
               environments+=("${{ github.event.inputs.environment }}")
             fi
           elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            environments+=("production")
+            # environments+=("production") # MEMO(YumNumm): 本番環境のデプロイを停止します。 手動でリダイレクト用のindex.htmlに更新済み
             environments+=("staging")
           else
             echo "他の条件に一致しないため、stagingにデプロイします"


### PR DESCRIPTION
## 説明

- チケットWebサイトのProductionデプロイを停止します
  - 既に リダイレクト用の`index.html`を手動で配置済みです