### PR TITLE
chore: セッション詳細のフィードバックボタンを削除

### DIFF
--- a/apps/app/pubspec.yaml
+++ b/apps/app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: conference_2024_app
 description: "FlutterKaigi 2024 official application."
 publish_to: "none"
-version: 2.0.0+11
+version: 2.0.1+12
 
 environment:
   sdk: ^3.6.0-216.1.beta

--- a/packages/app/features/session/assets/l10n/app_en.arb
+++ b/packages/app/features/session/assets/l10n/app_en.arb
@@ -4,8 +4,5 @@
   "registerToCalendar": "Register schedule to calendar",
   "sessionPageTitle": "Session",
   "sessionsPageTitle": "Sessions",
-  "shareOnX": "Share on X",
-  "feedback": "Feedback",
-  "sendFeedback": "Send feedback",
-  "feedbackFormUrl": "https://docs.google.com/forms/d/e/1FAIpQLSdBMjh96tcQlzdghbdveGSOJJujsv1X3OnJ7jm52Npv9KGc6A/viewform?usp=pp_url&entry.628975551={sessionId}"
+  "shareOnX": "Share on X"
 }

--- a/packages/app/features/session/assets/l10n/app_ja.arb
+++ b/packages/app/features/session/assets/l10n/app_ja.arb
@@ -4,17 +4,5 @@
   "registerToCalendar": "スケジュールをカレンダーに登録する",
   "sessionPageTitle": "Session",
   "sessionsPageTitle": "Sessions",
-  "shareOnX": "Xで共有する",
-  "feedback": "フィードバック",
-  "sendFeedback": "フィードバックを送信する",
-  "feedbackFormUrl": "https://docs.google.com/forms/d/e/1FAIpQLSd0AO8cZTt3pkBI1OjU5YUUzP_nXg6rSSz1r01ts6GJXPVymw/viewform?usp=pp_url&entry.628975551={sessionId}",
-  "@feedbackFormUrl": {
-    "placeholders": {
-      "sessionId": {
-        "type": "String",
-        "description": "Session ID",
-        "example": "a1ba9bfd-87c8-47b2-b5af-a50e0c64c300"
-      }
-    }
-  }
+  "shareOnX": "Xで共有する"
 }

--- a/packages/app/features/session/lib/src/gen/l10n/l10n.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n.dart
@@ -133,24 +133,6 @@ abstract class L10nSession {
   /// In ja, this message translates to:
   /// **'Xで共有する'**
   String get shareOnX;
-
-  /// No description provided for @feedback.
-  ///
-  /// In ja, this message translates to:
-  /// **'フィードバック'**
-  String get feedback;
-
-  /// No description provided for @sendFeedback.
-  ///
-  /// In ja, this message translates to:
-  /// **'フィードバックを送信する'**
-  String get sendFeedback;
-
-  /// No description provided for @feedbackFormUrl.
-  ///
-  /// In ja, this message translates to:
-  /// **'https://docs.google.com/forms/d/e/1FAIpQLSd0AO8cZTt3pkBI1OjU5YUUzP_nXg6rSSz1r01ts6GJXPVymw/viewform?usp=pp_url&entry.628975551={sessionId}'**
-  String feedbackFormUrl(String sessionId);
 }
 
 class _L10nSessionDelegate extends LocalizationsDelegate<L10nSession> {

--- a/packages/app/features/session/lib/src/gen/l10n/l10n_en.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n_en.dart
@@ -23,15 +23,4 @@ class L10nSessionEn extends L10nSession {
 
   @override
   String get shareOnX => 'Share on X';
-
-  @override
-  String get feedback => 'Feedback';
-
-  @override
-  String get sendFeedback => 'Send feedback';
-
-  @override
-  String feedbackFormUrl(String sessionId) {
-    return 'https://docs.google.com/forms/d/e/1FAIpQLSdBMjh96tcQlzdghbdveGSOJJujsv1X3OnJ7jm52Npv9KGc6A/viewform?usp=pp_url&entry.628975551=$sessionId';
-  }
 }

--- a/packages/app/features/session/lib/src/gen/l10n/l10n_ja.dart
+++ b/packages/app/features/session/lib/src/gen/l10n/l10n_ja.dart
@@ -23,15 +23,4 @@ class L10nSessionJa extends L10nSession {
 
   @override
   String get shareOnX => 'Xで共有する';
-
-  @override
-  String get feedback => 'フィードバック';
-
-  @override
-  String get sendFeedback => 'フィードバックを送信する';
-
-  @override
-  String feedbackFormUrl(String sessionId) {
-    return 'https://docs.google.com/forms/d/e/1FAIpQLSd0AO8cZTt3pkBI1OjU5YUUzP_nXg6rSSz1r01ts6GJXPVymw/viewform?usp=pp_url&entry.628975551=$sessionId';
-  }
 }

--- a/packages/app/features/session/lib/src/ui/session_page.dart
+++ b/packages/app/features/session/lib/src/ui/session_page.dart
@@ -238,28 +238,6 @@ class _SessionLayout extends ConsumerWidget with SessionPageMixin {
                     },
                   ),
                 ),
-                const Gap(16),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  child: Text(
-                    l.feedback,
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                ),
-                const Gap(8),
-                Tooltip(
-                  message: l.sendFeedback,
-                  child: ListTile(
-                    title: Text(l.sendFeedback),
-                    trailing: const Icon(Icons.arrow_outward),
-                    onTap: () {
-                      final formUrl = Uri.parse(l.feedbackFormUrl(_session.id));
-                      unawaited(
-                        launchInExternalApp(formUrl),
-                      );
-                    },
-                  ),
-                ),
                 const Gap(64),
               ],
             ),


### PR DESCRIPTION
## 概要
セッション詳細ページからフィードバックボタンとその関連機能を削除しました。

## 変更内容
- バージョンを2.0.0+11から2.0.1+12に更新
- セッション詳細ページからフィードバックボタンを削除
- 多言語対応ファイル（英語・日本語）からフィードバック関連の文字列を削除
- 生成されたローカライゼーションファイルからフィードバック関連のメソッドを削除

## 影響範囲
- セッション詳細ページのUI変更
- アプリのバージョン更新

## テスト
- [ ] セッション詳細ページでフィードバックボタンが表示されないことを確認
- [ ] アプリのバージョンが正しく更新されていることを確認

## スクリーンショット

| Before | After |
|-|-|
| <img width="320" height="2280" alt="before" src="https://github.com/user-attachments/assets/90de1db7-3605-4d63-9061-497e4be1cd07" /> | <img width="320" height="2280" alt="after" src="https://github.com/user-attachments/assets/678743ff-8224-4c7b-b930-896872531a5e" /> |
